### PR TITLE
fix: 카카오 로그인 API 수정 (#1)

### DIFF
--- a/src/main/java/com/palgona/palgona/common/dto/CustomMemberDetails.java
+++ b/src/main/java/com/palgona/palgona/common/dto/CustomMemberDetails.java
@@ -27,7 +27,7 @@ public class CustomMemberDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return member.getEmail();
+        return member.getSocialId();
     }
 
     @Override

--- a/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
@@ -65,9 +65,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void authenticate(HttpServletRequest request) {
         String accessToken = extractAccessToken(request).orElseThrow(
                 () -> new IllegalArgumentException("access Token is not valid"));
-        String email = jwtUtils.extractEmail(accessToken).orElseThrow(
+        String socialId = jwtUtils.extractSocialId(accessToken).orElseThrow(
                 () -> new IllegalArgumentException("access Token is not valid"));
-        Member member = memberRepository.findByEmail(email).orElseThrow(
+        Member member = memberRepository.findBySocialId(socialId).orElseThrow(
                 () -> new IllegalArgumentException("user is not exist"));
 
         saveAuthentication(member);
@@ -94,7 +94,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void reIssueTokens(HttpServletResponse response, String refreshToken) {
-        String email = jwtUtils.extractEmail(refreshToken).orElseThrow(
+        String email = jwtUtils.extractSocialId(refreshToken).orElseThrow(
                 () -> new IllegalArgumentException("refresh Token is not valid"));
 
         response.addHeader(REFRESH_HEADER, BEARER + jwtUtils.createRefreshToken(email));

--- a/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtUtils {
 
-    private static final String CLAIM = "email";
+    private static final String CLAIM = "socialId";
 
     @Value("${spring.jwt.access.expireMs}")
     private Long accessExpirationTime;
@@ -27,25 +27,25 @@ public class JwtUtils {
                 Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String createAccessToken(String email) {
+    public String createAccessToken(String socialId) {
         return Jwts.builder()
-                .claim(CLAIM, email)
+                .claim(CLAIM, socialId)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessExpirationTime))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public String createRefreshToken(String email) {
+    public String createRefreshToken(String socialId) {
         return Jwts.builder()
-                .claim(CLAIM, email)
+                .claim(CLAIM, socialId)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + refreshExpirationTime))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public Optional<String> extractEmail(String token) {
+    public Optional<String> extractSocialId(String token) {
         return Optional.ofNullable(Jwts.parser()
                 .verifyWith(secretKey)
                 .build()

--- a/src/main/java/com/palgona/palgona/controller/LoginController.java
+++ b/src/main/java/com/palgona/palgona/controller/LoginController.java
@@ -58,10 +58,10 @@ public class LoginController {
     ) {
 
         LoginResponse loginResponse = loginService.login(request);
-        String email = loginResponse.email();
+        String socialId = loginResponse.socialId();
 
-        String accessToken = jwtUtils.createAccessToken(email);
-        String refreshToken = jwtUtils.createRefreshToken(email);
+        String accessToken = jwtUtils.createAccessToken(socialId);
+        String refreshToken = jwtUtils.createRefreshToken(socialId);
         response.setHeader(AUTHORIZATION, BEARER + accessToken);
         response.setHeader(REFRESH_HEADER, BEARER + refreshToken);
 

--- a/src/main/java/com/palgona/palgona/domain/member/Member.java
+++ b/src/main/java/com/palgona/palgona/domain/member/Member.java
@@ -21,10 +21,13 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20, unique = true)
+    @Column(length = 20, unique = true)
     private String nickName;
 
     private int mileage;
+
+    @Column(nullable = false, unique = true)
+    private String socialId;
 
     private String profileImage;
 
@@ -32,27 +35,24 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private Status status;
 
-    @Column(nullable = false)
-    private String email;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
 
-    private Member(int mileage, Status status, String email, Role role) {
+    private Member(int mileage, Status status, String socialId, Role role) {
         this.mileage = mileage;
         this.status = status;
-        this.email = email;
+        this.socialId = socialId;
         this.role = role;
     }
 
     public static Member of(
             int mileage,
             Status status,
-            String email,
+            String socialId,
             Role role
     ) {
-        return new Member(mileage, status, email, role);
+        return new Member(mileage, status, socialId, role);
     }
 
     public boolean isUser() {

--- a/src/main/java/com/palgona/palgona/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/palgona/palgona/dto/KakaoUserInfoResponse.java
@@ -4,51 +4,9 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
 
+
 public record KakaoUserInfoResponse(
-        Long id,
-        LocalDateTime connectedAt,
-        KakaoAccount kakaoAccount
+        String id,
+        String connected_at
 ) {
-
-    public String extractEmail() {
-        return kakaoAccount.email;
-    }
-
-    @JsonNaming(SnakeCaseStrategy.class)
-    public record KakaoAccount(
-            boolean profileNeedsAgreement,
-            boolean profileNicknameNeedsAgreement,
-            boolean profileImageNeedsAgreement,
-            Profile profile,
-            boolean nameNeedsAgreement,
-            String name,
-            boolean emailNeedsAgreement,
-            boolean isEmailValid,
-            boolean isEmailVerified,
-            String email,
-            boolean ageRangeNeedsAgreement,
-            String ageRange,
-            boolean birthyearNeedsAgreement,
-            String birthyear,
-            boolean birthdayNeedsAgreement,
-            String birthday,
-            String birthdayType,
-            boolean genderNeedsAgreement,
-            String gender,
-            boolean phoneNumberNeedsAgreement,
-            String phoneNumber,
-            boolean ciNeedsAgreement,
-            String ci,
-            LocalDateTime ciAuthenticatedAt
-    ) {
-    }
-
-    @JsonNaming(SnakeCaseStrategy.class)
-    public record Profile(
-            String nickname,
-            String thumbnailImageUrl,
-            String profileImageUrl,
-            boolean isDefaultImage
-    ) {
-    }
 }

--- a/src/main/java/com/palgona/palgona/dto/LoginResponse.java
+++ b/src/main/java/com/palgona/palgona/dto/LoginResponse.java
@@ -4,13 +4,13 @@ import com.palgona.palgona.domain.member.Member;
 
 public record LoginResponse(
         Long id,
-        String email
+        String socialId
 ) {
 
     public static LoginResponse from(Member member) {
         return new LoginResponse(
                 member.getId(),
-                member.getEmail()
+                member.getSocialId()
         );
     }
 }

--- a/src/main/java/com/palgona/palgona/repository/MemberRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/MemberRepository.java
@@ -6,9 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByEmail(String email);
-
     boolean existsByNickName(String nickName);
 
-    boolean existsByEmail(String email);
+    Optional<Member> findBySocialId(String socialId);
 }


### PR DESCRIPTION
## 개요

- 카카오 소셜 로그인 수정

## 작업사항

- 사용자 정보 파싱해서 dto에 넣는 로직 구현

## 작업 대상
#1 

## 변경로직

- 기존의 jwt 토큰의 payload를 email을 사용했는데 socialId로 변경
- 카카오 사용자 정보 파싱해서 dto 에 넣는 로직 추가 작성
- 카카오 응답 dto 수정
