### PR TITLE
Feat/#3 입찰 마감 API 구현

### DIFF
--- a/src/main/java/com/palgona/palgona/PalgonaApplication.java
+++ b/src/main/java/com/palgona/palgona/PalgonaApplication.java
@@ -3,8 +3,10 @@ package com.palgona.palgona;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableJpaAuditing
 public class PalgonaApplication {
 

--- a/src/main/java/com/palgona/palgona/domain/bidding/Bidding.java
+++ b/src/main/java/com/palgona/palgona/domain/bidding/Bidding.java
@@ -17,7 +17,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
@@ -38,17 +37,19 @@ public class Bidding extends BaseTimeEntity {
     @Column(name = "price")
     private int price;
 
-    @Setter
     @Enumerated(EnumType.STRING)
     @Column(name = "state")
-    private BiddingStatus status;
+    private BiddingState state;
 
     @Builder
     Bidding(Product product, Member member, int price) {
         this.product = product;
         this.member = member;
         this.price = price;
-        this.status = BiddingStatus.ATTEMPT;
+        this.state = BiddingState.ATTEMPT;
     }
 
+    public void updateState(BiddingState state) {
+        this.state = state;
+    }
 }

--- a/src/main/java/com/palgona/palgona/domain/bidding/Bidding.java
+++ b/src/main/java/com/palgona/palgona/domain/bidding/Bidding.java
@@ -1,5 +1,6 @@
 package com.palgona.palgona.domain.bidding;
 
+import com.palgona.palgona.common.entity.BaseTimeEntity;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.product.Product;
 import jakarta.persistence.Column;
@@ -14,11 +15,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Bidding {
+public class Bidding extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,6 +38,7 @@ public class Bidding {
     @Column(name = "price")
     private int price;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(name = "state")
     private BiddingStatus status;
@@ -45,4 +50,5 @@ public class Bidding {
         this.price = price;
         this.status = BiddingStatus.ATTEMPT;
     }
+
 }

--- a/src/main/java/com/palgona/palgona/domain/bidding/BiddingState.java
+++ b/src/main/java/com/palgona/palgona/domain/bidding/BiddingState.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public enum BiddingStatus {
+public enum BiddingState {
     SUCCESS("SUCCESS", "성공"),
     FAILED("FAILED", "실패"),
     ATTEMPT("ATTEMPT", "시도");

--- a/src/main/java/com/palgona/palgona/domain/member/Member.java
+++ b/src/main/java/com/palgona/palgona/domain/member/Member.java
@@ -46,12 +46,7 @@ public class Member extends BaseTimeEntity {
         this.role = role;
     }
 
-    public static Member of(
-            int mileage,
-            Status status,
-            String socialId,
-            Role role
-    ) {
+    public static Member of(int mileage, Status status, String socialId, Role role) {
         return new Member(mileage, status, socialId, role);
     }
 

--- a/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
@@ -13,6 +13,6 @@ import org.springframework.data.repository.query.Param;
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
     Page<Bidding> findAllByProduct(Pageable pageable, Product product);
-    @Query("SELECT b FROM Bidding b WHERE b.status = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
+    @Query("SELECT b FROM Bidding b WHERE b.state = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
     List<Bidding> findExpiredBiddings(@Param("currentDateTime") LocalDateTime currentDateTime);
 }

--- a/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
@@ -2,11 +2,17 @@ package com.palgona.palgona.repository;
 
 import com.palgona.palgona.domain.bidding.Bidding;
 import com.palgona.palgona.domain.product.Product;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
     Page<Bidding> findAllByProduct(Pageable pageable, Product product);
+    @Query("SELECT b FROM Bidding b WHERE b.status = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
+    List<Bidding> findExpiredBiddings(@Param("currentDateTime") LocalDateTime currentDateTime);
 }

--- a/src/main/java/com/palgona/palgona/service/BatchScheduler.java
+++ b/src/main/java/com/palgona/palgona/service/BatchScheduler.java
@@ -1,0 +1,17 @@
+package com.palgona.palgona.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BatchScheduler {
+
+    private final BiddingService biddingService;
+
+    @Scheduled(cron = "0 0/5 * * * ?") // 5분 주기로 실행
+    public void checkBiddingExpiration() {
+        biddingService.checkBiddingExpiration();
+    }
+}

--- a/src/main/java/com/palgona/palgona/service/BatchScheduler.java
+++ b/src/main/java/com/palgona/palgona/service/BatchScheduler.java
@@ -10,7 +10,7 @@ public class BatchScheduler {
 
     private final BiddingService biddingService;
 
-    @Scheduled(cron = "0 0/5 * * * ?") // 5분 주기로 실행
+    @Scheduled(cron = "0/30 * * * * ?") // 5분 주기로 실행
     public void checkBiddingExpiration() {
         biddingService.checkBiddingExpiration();
     }

--- a/src/main/java/com/palgona/palgona/service/BiddingService.java
+++ b/src/main/java/com/palgona/palgona/service/BiddingService.java
@@ -1,11 +1,16 @@
 package com.palgona.palgona.service;
 
 import com.palgona.palgona.domain.bidding.Bidding;
+import com.palgona.palgona.domain.bidding.BiddingStatus;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.product.Product;
 import com.palgona.palgona.dto.BiddingAttemptRequest;
 import com.palgona.palgona.repository.BiddingRepository;
 import com.palgona.palgona.repository.ProductRepository;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,11 +29,7 @@ public class BiddingService {
             throw new RuntimeException("이미 입찰 마감된 상품입니다.");
         }
 
-        Bidding bidding = Bidding.builder()
-                .member(member)
-                .product(product)
-                .price(request.price())
-                .build();
+        Bidding bidding = Bidding.builder().member(member).product(product).price(request.price()).build();
 
         biddingRepository.save(bidding);
     }
@@ -38,5 +39,41 @@ public class BiddingService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 product가 없습니다."));
 
         return biddingRepository.findAllByProduct(pageable, product);
+    }
+
+    public void checkBiddingExpiration() {
+        List<Bidding> expiredBiddings = biddingRepository.findExpiredBiddings(LocalDateTime.now());
+
+        Map<Long, Bidding> highestPriceBiddings = new HashMap<>();
+
+        // expiredBiddings를 순회하며 각 product_id에 대한 가장 높은 price를 가진 Bidding을 저장
+        for (Bidding bidding : expiredBiddings) {
+            Long productId = bidding.getProduct().getId();
+
+            highestPriceBiddings.compute(productId, (key, oldValue) -> {
+                if (oldValue == null || bidding.getPrice() > oldValue.getPrice() || (
+                        bidding.getPrice() == oldValue.getPrice() && bidding.getUpdatedAt()
+                                .isBefore(oldValue.getUpdatedAt()))) {
+                    return bidding;
+                } else {
+                    return oldValue;
+                }
+            });
+        }
+
+        for (Bidding bidding : expiredBiddings) {
+            Long productId = bidding.getProduct().getId();
+            Bidding highestPriceBidding = highestPriceBiddings.get(productId);
+
+            // 가장 높은 가격을 가진 Bidding이면 SUCCESS로, 그렇지 않으면 FAILED로 상태 변경
+            if (bidding.getId().equals(highestPriceBidding.getId())) {
+                bidding.setStatus(BiddingStatus.SUCCESS);
+            } else {
+                bidding.setStatus(BiddingStatus.FAILED);
+            }
+
+            // 변경된 상태를 저장
+            biddingRepository.save(bidding);
+        }
     }
 }

--- a/src/main/resources/example.sql
+++ b/src/main/resources/example.sql
@@ -1,0 +1,19 @@
+-- Member 테이블에 예시값 삽입
+INSERT INTO member (nick_name, mileage, social_id, profile_image, status, role)
+VALUES
+    ('user1', 100, '1234567890', 'profile1.jpg', 'ACTIVE', 'USER'),
+    ('user2', 150, '0987654321', 'profile2.jpg', 'ACTIVE', 'USER');
+
+-- Product 테이블에 예시값 삽입
+INSERT INTO product (name, initial_price, content, category, deadline, member_id)
+VALUES
+    ('Product 1', 1000, 'Content for Product 1', 'DIGITAL_DEVICE',(DATE_ADD(NOW(), INTERVAL 1 MINUTE)), 1),
+    ('Product 2', 2000, 'Content for Product 2', 'CLOTHING', (DATE_ADD(NOW(), INTERVAL 1 MINUTE)), 2);
+
+-- Bidding 테이블에 예시값 삽입
+INSERT INTO bidding (product_id, member_id, price, state)
+VALUES
+    (1, 1, 1200, 'ATTEMPT'),
+    (1, 2, 1500, 'ATTEMPT'),
+    (2, 1, 2200, 'ATTEMPT'),
+    (2, 2, 1800, 'ATTEMPT');


### PR DESCRIPTION
## 개요

- 입찰 마감에 대해 처리하자
- #3 

## 작업사항

- 5분마다 입찰 마감된 product를 탐색
- 마감된 물건에서 가장 높은 값을 찾아 `SUCCESS`, 나머진 `FAILED`로 상태 변경
- 만약 같은 값이 있을 경우 updateAt이 오래된 것으로 선택
- 성능을 위해 Map에 미리 찾아 저장 후 비교하는 방식으로 구현

## 변경로직

- `BiddingRepository`에 `findExpiredBiddings`추가
- Service에 `BatchScheduler` 추가
