### PR TITLE
Feat/#29 인증 필터 방식 변경

### DIFF
--- a/src/main/java/com/palgona/palgona/common/error/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/palgona/palgona/common/error/advice/GlobalExceptionHandler.java
@@ -3,16 +3,19 @@ package com.palgona.palgona.common.error.advice;
 import com.palgona.palgona.common.error.exception.BusinessException;
 import com.palgona.palgona.common.error.code.ErrorCode;
 import com.palgona.palgona.common.error.dto.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler
+    @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handle(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
+        log.warn("code = {} message = {}", errorCode.getCode(), errorCode.getMessage());
 
         return ResponseEntity.status(e.getStatus()).body(ErrorResponse.from(errorCode));
     }

--- a/src/main/java/com/palgona/palgona/common/error/code/AuthErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/AuthErrorCode.java
@@ -9,7 +9,8 @@ public enum AuthErrorCode implements ErrorCode {
     ILLEGAL_TOKEN(HttpStatus.UNAUTHORIZED, "A_002", "잘못된 JWT 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A_003", "만료된 JWT 토큰입니다."),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "A_004", "잘못된 JWT 서명입니다."),
-    NOT_SUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "A_005", "지원되지 않는 JWT 토큰입니다.");
+    NOT_SUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "A_005", "지원되지 않는 JWT 토큰입니다."),
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "A_006", "접근 권한이 없는 리소스입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/palgona/palgona/common/error/code/AuthErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/AuthErrorCode.java
@@ -10,7 +10,8 @@ public enum AuthErrorCode implements ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A_003", "만료된 JWT 토큰입니다."),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "A_004", "잘못된 JWT 서명입니다."),
     NOT_SUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "A_005", "지원되지 않는 JWT 토큰입니다."),
-    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "A_006", "접근 권한이 없는 리소스입니다.");
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "A_006", "접근 권한이 없는 리소스입니다."),
+    ILLEGAL_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "A_007", "잘못된 카카오 토큰입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/palgona/palgona/common/error/code/AuthErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/AuthErrorCode.java
@@ -1,0 +1,28 @@
+package com.palgona.palgona.common.error.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthErrorCode implements ErrorCode {
+
+    ILLEGAL_TOKEN(HttpStatus.UNAUTHORIZED, "A_002", "잘못된 JWT 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A_003", "만료된 JWT 토큰입니다."),
+    INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "A_004", "잘못된 JWT 서명입니다."),
+    NOT_SUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "A_005", "지원되지 않는 JWT 토큰입니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(
+            HttpStatus status,
+            String code,
+            String message
+    ) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
@@ -6,8 +6,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum MemberErrorCode implements ErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NO_CONTENT, "C_001", "해당 유저를 찾을 수 없습니다."),
-    ADMIN_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "C_002", "관리자 권한으로만 접근할 수 있는 리소스입니다.");
+    MEMBER_NOT_EXIST(HttpStatus.NO_CONTENT, "C_001", "해당 유저를 찾을 수 없습니다."),
+    ADMIN_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "C_002", "관리자 권한으로만 접근할 수 있는 리소스입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.OK, "C_003", "해당 유저를 찾을 수 없습니다."),
+    ALREADY_SIGNED_UP(HttpStatus.BAD_REQUEST, "C_004", "이미 회원가입된 유저입니다."),
+    DUPLICATE_NAME(HttpStatus.BAD_REQUEST, "C_005", "이미 존재하는 닉네임입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum MemberErrorCode implements ErrorCode {
-    MEMBER_NOT_FOUND(HttpStatus.NO_CONTENT, "C_001", "해당 유저를 찾을 수 없습니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "C_001", "해당 유저를 찾을 수 없습니다."),
     ADMIN_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "C_002", "관리자 권한으로만 접근할 수 있는 리소스입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum MemberErrorCode implements ErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "C_001", "해당 유저를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NO_CONTENT, "C_001", "해당 유저를 찾을 수 없습니다."),
     ADMIN_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "C_002", "관리자 권한으로만 접근할 수 있는 리소스입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
@@ -1,19 +1,20 @@
 package com.palgona.palgona.common.jwt.filter;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
 import com.palgona.palgona.common.dto.CustomMemberDetails;
+import com.palgona.palgona.common.error.code.AuthErrorCode;
 import com.palgona.palgona.common.jwt.util.JwtUtils;
+import com.palgona.palgona.common.jwt.util.TokenExtractor;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.repository.member.MemberRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,56 +22,49 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private static final String BEARER = "Bearer ";
-    private static final String REFRESH_HEADER = "refresh-Authorization";
-    private static final List<RequestMatcher> permittedRequestMatcher = Arrays.asList(
-            new AntPathRequestMatcher("/api/v1/auth/login"),
-            new AntPathRequestMatcher("/v3/**"),
-            new AntPathRequestMatcher("/swagger-ui/**"));
+
+    private static final String EXCEPTION = "exception";
 
     private final JwtUtils jwtUtils;
-
     private final MemberRepository memberRepository;
+    private final TokenExtractor tokenExtractor;
 
     private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        log.info(request.getRequestURI());
-        for (RequestMatcher requestMatcher : permittedRequestMatcher) {
-            if (requestMatcher.matches(request)) {
-                filterChain.doFilter(request, response);
-                return;
-            }
-        }
 
-        String refreshToken = extractRefreshToken(request)
-                .filter(token -> !jwtUtils.isExpired(token))
-                .orElse(null);
-        if (refreshToken == null) {
-            authenticate(request);
-        } else {
-            reIssueTokens(response, refreshToken);
-        }
+        log.info(request.getRequestURI());
+        authenticate(request);
         filterChain.doFilter(request, response);
     }
 
     private void authenticate(HttpServletRequest request) {
-        String accessToken = extractAccessToken(request).orElseThrow(
-                () -> new IllegalArgumentException("access Token is not valid"));
-        String socialId = jwtUtils.extractSocialId(accessToken).orElseThrow(
-                () -> new IllegalArgumentException("access Token is not valid"));
-        Member member = memberRepository.findBySocialId(socialId).orElseThrow(
-                () -> new IllegalArgumentException("user is not exist"));
-        saveAuthentication(member);
+        try {
+            String accessToken = tokenExtractor.extractAccessToken(request);
+            if (jwtUtils.isValid(accessToken)) {
+                String socialId = jwtUtils.extractSocialId(accessToken)
+                        .orElseThrow(() -> new IllegalArgumentException());
+                Member member = memberRepository.findBySocialId(socialId)
+                        .orElseThrow(() -> new IllegalArgumentException());
+
+                saveAuthentication(member);
+            }
+        } catch (SecurityException | MalformedJwtException e) {
+            request.setAttribute(EXCEPTION, AuthErrorCode.INVALID_SIGNATURE);
+        } catch (ExpiredJwtException e) {
+            request.setAttribute(EXCEPTION, AuthErrorCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            request.setAttribute(EXCEPTION, AuthErrorCode.NOT_SUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            request.setAttribute(EXCEPTION, AuthErrorCode.ILLEGAL_TOKEN);
+        }
     }
 
     private void saveAuthentication(Member member) {
@@ -79,25 +73,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 customMemberDetails, null,
                 authoritiesMapper.mapAuthorities(customMemberDetails.getAuthorities()));
         SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
-    private Optional<String> extractRefreshToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(REFRESH_HEADER))
-                .filter(token -> token.startsWith(BEARER))
-                .map(token -> token.replace(BEARER, ""));
-    }
-
-    private Optional<String> extractAccessToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(AUTHORIZATION))
-                .filter(token -> token.startsWith(BEARER))
-                .map(token -> token.replace(BEARER, ""));
-    }
-
-    private void reIssueTokens(HttpServletResponse response, String refreshToken) {
-        String email = jwtUtils.extractSocialId(refreshToken).orElseThrow(
-                () -> new IllegalArgumentException("refresh Token is not valid"));
-
-        response.addHeader(REFRESH_HEADER, BEARER + jwtUtils.createRefreshToken(email));
-        response.addHeader(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(email));
     }
 }

--- a/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
@@ -48,7 +48,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void authenticate(HttpServletRequest request) {
         try {
             String accessToken = tokenExtractor.extractAccessToken(request);
-            if (jwtUtils.isValid(accessToken)) {
+            if (!jwtUtils.isExpired(accessToken)) {
                 String socialId = jwtUtils.extractSocialId(accessToken)
                         .orElseThrow(() -> new IllegalArgumentException());
                 Member member = memberRepository.findBySocialId(socialId)

--- a/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAccessDeniedHandler.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     private final ObjectMapper objectMapper;
@@ -25,6 +27,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
 
+        log.warn("인가되지 않은 자원에 접근했습니다.");
         ErrorResponse errorResponse = ErrorResponse.from(FORBIDDEN_ACCESS);
         setResponse(response, errorResponse);
     }

--- a/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.palgona.palgona.common.jwt.handler;
+
+import static com.palgona.palgona.common.error.code.AuthErrorCode.FORBIDDEN_ACCESS;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palgona.palgona.common.error.dto.response.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        ErrorResponse errorResponse = ErrorResponse.from(FORBIDDEN_ACCESS);
+        setResponse(response, errorResponse);
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorResponse errorResponse) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.palgona.palgona.common.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palgona.palgona.common.error.code.AuthErrorCode;
+import com.palgona.palgona.common.error.dto.response.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final String EXCEPTION = "exception";
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        AuthErrorCode errorCode = (AuthErrorCode) request.getAttribute(EXCEPTION);
+        ErrorResponse errorResponse = ErrorResponse.from(errorCode);
+        setResponse(response, errorResponse);
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorResponse errorResponse) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,7 @@
 package com.palgona.palgona.common.jwt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.palgona.palgona.common.error.code.AuthErrorCode;
+import com.palgona.palgona.common.error.code.ErrorCode;
 import com.palgona.palgona.common.error.dto.response.ErrorResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,7 +28,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException, ServletException {
 
-        AuthErrorCode errorCode = (AuthErrorCode) request.getAttribute(EXCEPTION);
+        log.info("유저 인증에 실패했습니다.");
+        ErrorCode errorCode = (ErrorCode) request.getAttribute(EXCEPTION);
         ErrorResponse errorResponse = ErrorResponse.from(errorCode);
         setResponse(response, errorResponse);
     }

--- a/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
@@ -1,5 +1,9 @@
 package com.palgona.palgona.common.jwt.util;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -54,7 +58,7 @@ public class JwtUtils {
                 .get(CLAIM, String.class));
     }
 
-    public Boolean isValid(String token) {
+    public Boolean isExpired(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()

--- a/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
@@ -54,7 +54,7 @@ public class JwtUtils {
                 .get(CLAIM, String.class));
     }
 
-    public Boolean isExpired(String token) {
+    public Boolean isValid(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()

--- a/src/main/java/com/palgona/palgona/common/jwt/util/TokenExtractor.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/util/TokenExtractor.java
@@ -1,0 +1,36 @@
+package com.palgona.palgona.common.jwt.util;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class TokenExtractor {
+
+    private static final String REFRESH_HEADER = "Refresh-token";
+    private static final String BEARER = "Bearer ";
+
+    public String extractRefreshToken(HttpServletRequest request) {
+        String refreshToken = request.getHeader(REFRESH_HEADER);
+        if (StringUtils.hasText(refreshToken) && isBearerToken(refreshToken)) {
+            return refreshToken.substring(7);
+        }
+
+        return null;
+    }
+
+    public String extractAccessToken(HttpServletRequest request) {
+        String accessToken = request.getHeader(AUTHORIZATION);
+        if (StringUtils.hasText(accessToken) && isBearerToken(accessToken)) {
+            return accessToken.substring(7);
+        }
+
+        return null;
+    }
+
+    private boolean isBearerToken(String refreshToken) {
+        return refreshToken.toLowerCase().startsWith(BEARER.toLowerCase());
+    }
+}

--- a/src/main/java/com/palgona/palgona/config/SecurityConfig.java
+++ b/src/main/java/com/palgona/palgona/config/SecurityConfig.java
@@ -1,13 +1,16 @@
 package com.palgona.palgona.config;
 
 import com.palgona.palgona.common.jwt.filter.JwtAuthenticationFilter;
+import com.palgona.palgona.common.jwt.handler.JwtAuthenticationEntryPoint;
 import com.palgona.palgona.common.jwt.util.JwtUtils;
 import com.palgona.palgona.repository.member.MemberRepository;
+import com.palgona.palgona.common.jwt.util.TokenExtractor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -19,18 +22,24 @@ public class SecurityConfig {
 
     private final JwtUtils jwtUtils;
     private final MemberRepository memberRepository;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final TokenExtractor tokenExtractor;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(config -> config.disable())
-                .formLogin(config -> config.disable())
-                .httpBasic(config -> config.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptionHandlingConfigurer -> {
+                    exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+                })
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/login", "/v3/**", "swagger-ui/**").permitAll()
+                        .requestMatchers("/api/v1/auth/login").permitAll()
+                        .requestMatchers("/v3/**", "swagger-ui/**").permitAll()
                         .anyRequest().authenticated())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtUtils, memberRepository),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtils, memberRepository, tokenExtractor),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/palgona/palgona/config/SecurityConfig.java
+++ b/src/main/java/com/palgona/palgona/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import com.palgona.palgona.common.jwt.util.TokenExtractor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -19,6 +21,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private static final String ADMIN = "ADMIN";
+    private static final String USER = "USER";
+    private static final String GUEST = "GUEST";
 
     private final JwtUtils jwtUtils;
     private final MemberRepository memberRepository;
@@ -37,11 +43,24 @@ public class SecurityConfig {
                 })
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/login").permitAll()
+                        .requestMatchers("/api/v1/auth/signup").hasRole(GUEST)
                         .requestMatchers("/v3/**", "swagger-ui/**").permitAll()
+                        .requestMatchers("/api/v1/members").hasRole(ADMIN)
+                        .requestMatchers("/api/v1/members/**").hasRole(USER)
+                        .requestMatchers("/api/v1/products/**").hasRole(USER)
+                        .requestMatchers("/api/v1/biddings/**").hasRole(USER)
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtils, memberRepository, tokenExtractor),
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
+        hierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER > ROLE_GUEST");
+
+        return hierarchy;
     }
 }

--- a/src/main/java/com/palgona/palgona/config/SecurityConfig.java
+++ b/src/main/java/com/palgona/palgona/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.palgona.palgona.config;
 
 import com.palgona.palgona.common.jwt.filter.JwtAuthenticationFilter;
+import com.palgona.palgona.common.jwt.handler.JwtAccessDeniedHandler;
 import com.palgona.palgona.common.jwt.handler.JwtAuthenticationEntryPoint;
 import com.palgona.palgona.common.jwt.util.JwtUtils;
 import com.palgona.palgona.repository.member.MemberRepository;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final JwtUtils jwtUtils;
     private final MemberRepository memberRepository;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final TokenExtractor tokenExtractor;
 
     @Bean
@@ -40,6 +42,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(exceptionHandlingConfigurer -> {
                     exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+                    exceptionHandlingConfigurer.accessDeniedHandler(jwtAccessDeniedHandler);
                 })
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/login").permitAll()

--- a/src/main/java/com/palgona/palgona/controller/MemberController.java
+++ b/src/main/java/com/palgona/palgona/controller/MemberController.java
@@ -47,10 +47,9 @@ public class MemberController {
 
     @GetMapping
     public ResponseEntity<SliceResponse<MemberResponse>> findAll(
-            @AuthenticationPrincipal CustomMemberDetails member,
             @RequestParam(required = false) String cursor) {
 
-        SliceResponse<MemberResponse> response = memberService.findAllMember(member, cursor);
+        SliceResponse<MemberResponse> response = memberService.findAllMember(cursor);
         return ResponseEntity.ok(response);
     }
 
@@ -58,7 +57,7 @@ public class MemberController {
     public ResponseEntity<Void> update(
             @AuthenticationPrincipal CustomMemberDetails member,
             @RequestPart MemberUpdateRequestWithoutImage request,
-            @RequestPart(required = false) MultipartFile image
+            @RequestPart MultipartFile image
     ) {
 
         MemberUpdateRequest memberUpdateRequest = MemberUpdateRequest.of(request, image);

--- a/src/main/java/com/palgona/palgona/domain/member/Member.java
+++ b/src/main/java/com/palgona/palgona/domain/member/Member.java
@@ -69,4 +69,8 @@ public class Member extends BaseTimeEntity {
     public void updateProfileImage(String imageUrl) {
         this.profileImage = imageUrl;
     }
+
+    public void signUp() {
+        this.role = Role.USER;
+    }
 }

--- a/src/main/java/com/palgona/palgona/service/LoginService.java
+++ b/src/main/java/com/palgona/palgona/service/LoginService.java
@@ -49,7 +49,7 @@ public class LoginService {
         String imageUrl = s3Service.upload(image);
         member.updateNickName(nickName);
         member.updateProfileImage(imageUrl);
-
+        member.signUp();
         return member.getId();
     }
 

--- a/src/main/java/com/palgona/palgona/service/LoginService.java
+++ b/src/main/java/com/palgona/palgona/service/LoginService.java
@@ -1,11 +1,14 @@
 package com.palgona.palgona.service;
 
 
+import static com.palgona.palgona.common.error.code.AuthErrorCode.*;
+import static com.palgona.palgona.common.error.code.MemberErrorCode.*;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palgona.palgona.common.dto.CustomMemberDetails;
+import com.palgona.palgona.common.error.exception.BusinessException;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.member.Role;
 import com.palgona.palgona.domain.member.Status;
@@ -72,12 +75,17 @@ public class LoginService {
 
     private KakaoUserInfoResponse getKakaoUserInfo(String accessToken) {
         HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = getKakaoRequest(accessToken);
-        ResponseEntity<String> kakaoResponse = restTemplate.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.GET,
-                kakaoUserInfoRequest,
-                String.class
-        );
+        ResponseEntity<String> kakaoResponse = null;
+        try {
+            kakaoResponse = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.GET,
+                    kakaoUserInfoRequest,
+                    String.class
+            );
+        } catch (Exception e) {
+            throw new BusinessException(ILLEGAL_KAKAO_TOKEN);
+        }
 
         KakaoUserInfoResponse kakaoUserInfoResponse = parseKakaoInfo(kakaoResponse);
 
@@ -115,25 +123,25 @@ public class LoginService {
 
     private void validateToken(String token) {
         if (token == null || !token.toLowerCase().startsWith(BEARER.toLowerCase())) {
-            throw new IllegalArgumentException("invalid kakao Access Token");
+            throw new BusinessException(ILLEGAL_KAKAO_TOKEN);
         }
     }
 
     private void validateRoleOfMember(Member member) {
         if (!member.isGuest()) {
-            throw new IllegalStateException("already signUp");
+            throw new BusinessException(ALREADY_SIGNED_UP);
         }
     }
 
     private void validateNameDuplicated(String nickName) {
         if (memberRepository.existsByNickName(nickName)) {
-            throw new IllegalArgumentException("nickName is duplicated");
+            throw new BusinessException(DUPLICATE_NAME);
         }
     }
 
     private Member findMemberBySocialId(CustomMemberDetails loginMember) {
         String socialId = loginMember.getUsername();
         return memberRepository.findBySocialId(socialId).orElseThrow(
-                () -> new IllegalArgumentException("user is not exist"));
+                () -> new BusinessException(MEMBER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 개요

- #29
- #1 

## 작업사항

- JwtFilter 예외 핸들러 구현
- 인증 관련 에러코드 추가
- Jwt 토큰 추출 객체 분리
- 인가 설정 및 Role 계층 구조 추가
- 회원 가입 시 Role 변경 로직 추가

## 변경로직

- `LongService` 에 Singup 로직 수정
- `JwtAuthenticationFilter`에서 URL 필터링 로직 삭제하고 `AuthenticationEntryPoint` 에서 예외 처리
