### PR TITLE
Feat/#36 로그아웃 기능

### DIFF
--- a/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import com.palgona.palgona.common.dto.CustomMemberDetails;
 import com.palgona.palgona.common.error.code.AuthErrorCode;
 import com.palgona.palgona.common.jwt.util.JwtUtils;
 import com.palgona.palgona.common.jwt.util.TokenExtractor;
+import com.palgona.palgona.common.redis.RedisUtils;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.repository.member.MemberRepository;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -33,6 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtils jwtUtils;
     private final MemberRepository memberRepository;
     private final TokenExtractor tokenExtractor;
+    private final RedisUtils redisUtils;
 
     private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
 
@@ -48,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void authenticate(HttpServletRequest request) {
         try {
             String accessToken = tokenExtractor.extractAccessToken(request);
-            if (!jwtUtils.isExpired(accessToken)) {
+            if (!jwtUtils.isExpired(accessToken) || !redisUtils.isBlacklist(accessToken)) {
                 String socialId = jwtUtils.extractSocialId(accessToken)
                         .orElseThrow(() -> new IllegalArgumentException());
                 Member member = memberRepository.findBySocialId(socialId)

--- a/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/filter/JwtAuthenticationFilter.java
@@ -50,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void authenticate(HttpServletRequest request) {
         try {
             String accessToken = tokenExtractor.extractAccessToken(request);
-            if (!jwtUtils.isExpired(accessToken) || !redisUtils.isBlacklist(accessToken)) {
+            if (!jwtUtils.isExpired(accessToken) && !redisUtils.isBlacklist(accessToken)) {
                 String socialId = jwtUtils.extractSocialId(accessToken)
                         .orElseThrow(() -> new IllegalArgumentException());
                 Member member = memberRepository.findBySocialId(socialId)

--- a/src/main/java/com/palgona/palgona/common/jwt/util/JwtService.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/util/JwtService.java
@@ -1,0 +1,63 @@
+package com.palgona.palgona.common.jwt.util;
+
+import static com.palgona.palgona.common.error.code.AuthErrorCode.ILLEGAL_TOKEN;
+
+import com.palgona.palgona.common.error.exception.BusinessException;
+import com.palgona.palgona.domain.RefreshToken;
+import com.palgona.palgona.dto.AuthToken;
+import com.palgona.palgona.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class JwtService {
+
+    private final JwtUtils jwtUtils;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public AuthToken issueToken(String socialId) {
+        String accessToken = jwtUtils.createAccessToken(socialId);
+        String refreshToken = jwtUtils.createRefreshToken(socialId);
+
+        if (refreshTokenRepository.existsBySocialId(socialId)) {
+            refreshTokenRepository.deleteBySocialId(socialId);
+        }
+
+        refreshTokenRepository.save(new RefreshToken(refreshToken, socialId));
+
+        return new AuthToken(accessToken, refreshToken);
+    }
+
+    public AuthToken reissueToken(String accessToken, String refreshToken) {
+        validateTokenReissue(accessToken, refreshToken);
+        String socialId = findSocialIdByRefreshToken(refreshToken);
+
+        return issueToken(socialId);
+    }
+
+    public void removeRefreshToken(String refreshToken) {
+        validateTokenRemove(refreshToken);
+        refreshTokenRepository.deleteById(refreshToken);
+    }
+
+    private String findSocialIdByRefreshToken(String token) {
+        RefreshToken refreshToken = refreshTokenRepository.findById(token)
+                .orElseThrow(() -> new BusinessException(ILLEGAL_TOKEN));
+        return refreshToken.getSocialId();
+    }
+
+    private void validateTokenReissue(String accessToken, String refreshToken) {
+        if (!jwtUtils.isExpired(refreshToken) && jwtUtils.isExpired(accessToken)) {
+            return;
+        }
+
+        throw new BusinessException(ILLEGAL_TOKEN);
+    }
+
+    private void validateTokenRemove(String refreshToken) {
+        if (jwtUtils.isExpired(refreshToken)) {
+            throw new BusinessException(ILLEGAL_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
+++ b/src/main/java/com/palgona/palgona/common/jwt/util/JwtUtils.java
@@ -1,9 +1,5 @@
 package com.palgona.palgona.common.jwt.util;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;

--- a/src/main/java/com/palgona/palgona/common/redis/RedisUtils.java
+++ b/src/main/java/com/palgona/palgona/common/redis/RedisUtils.java
@@ -1,0 +1,21 @@
+package com.palgona.palgona.common.redis;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtils {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setBlacklist(String key, Long expirationTime) {
+        redisTemplate.opsForValue().set(key, key, expirationTime, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean isBlacklist(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+}

--- a/src/main/java/com/palgona/palgona/config/RedisConfig.java
+++ b/src/main/java/com/palgona/palgona/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.palgona.palgona.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/palgona/palgona/domain/RefreshToken.java
+++ b/src/main/java/com/palgona/palgona/domain/RefreshToken.java
@@ -1,0 +1,27 @@
+package com.palgona.palgona.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    private String token;
+
+    @Column(nullable = false, unique = true)
+    private String socialId;
+
+    @Builder
+    public RefreshToken(String token, String socialId) {
+        this.token = token;
+        this.socialId = socialId;
+    }
+}

--- a/src/main/java/com/palgona/palgona/dto/AuthToken.java
+++ b/src/main/java/com/palgona/palgona/dto/AuthToken.java
@@ -1,0 +1,4 @@
+package com.palgona.palgona.dto;
+
+public record AuthToken(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/palgona/palgona/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.palgona.palgona.repository;
+
+import com.palgona.palgona.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+
+    boolean existsBySocialId(String socialId);
+
+    void deleteBySocialId(String socialId);
+}

--- a/src/test/java/com/palgona/palgona/PalgonaApplicationTests.java
+++ b/src/test/java/com/palgona/palgona/PalgonaApplicationTests.java
@@ -6,8 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class PalgonaApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+    }
 }

--- a/src/test/java/com/palgona/palgona/controller/login/LoginControllerTest.java
+++ b/src/test/java/com/palgona/palgona/controller/login/LoginControllerTest.java
@@ -1,0 +1,123 @@
+package com.palgona.palgona.controller.login;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palgona.palgona.common.jwt.util.JwtService;
+import com.palgona.palgona.common.jwt.util.JwtUtils;
+import com.palgona.palgona.dto.AuthToken;
+import com.palgona.palgona.dto.LoginResponse;
+import com.palgona.palgona.dto.MemberCreateRequestWithoutImage;
+import com.palgona.palgona.service.LoginService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class LoginControllerTest {
+
+    private static final String BEARER = "Bearer ";
+    private static final String USER_SOCIAL_ID = "1234";
+    private static final String GUEST_SOCIAL_ID = "123";
+    private static final String REFRESH_HEADER = "refresh-token";
+
+    @MockBean
+    LoginService loginService;
+
+    @MockBean
+    JwtService jwtService;
+
+    @Autowired
+    JwtUtils jwtUtils;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void 로그인_테스트() throws Exception {
+
+        LoginResponse loginResponse = new LoginResponse(1L, GUEST_SOCIAL_ID);
+
+        AuthToken authToken = new AuthToken(
+                jwtUtils.createAccessToken(GUEST_SOCIAL_ID),
+                jwtUtils.createRefreshToken(GUEST_SOCIAL_ID)
+        );
+
+        given(loginService.login(any())).willReturn(loginResponse);
+        given(jwtService.issueToken(GUEST_SOCIAL_ID)).willReturn(authToken);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/auth/login"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void 회원가입_테스트() throws Exception {
+
+        MemberCreateRequestWithoutImage createRequest = new MemberCreateRequestWithoutImage("닉네임");
+
+        given(loginService.signUp(any(), any())).willReturn(1L);
+
+        MockMultipartFile request = new MockMultipartFile(
+                "request",
+                "request",
+                APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(createRequest)
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(POST, "/api/v1/auth/signup")
+                        .file(request)
+                        .file(image)
+                .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(USER_SOCIAL_ID))
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(MockMvcResultMatchers.status().isCreated());
+    }
+
+    @Test
+    void 로그아웃_테스트() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/logout")
+                        .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(USER_SOCIAL_ID))
+                        .header(REFRESH_HEADER, BEARER + jwtUtils.createRefreshToken(USER_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+
+    @Test
+    void 리프레쉬_토큰_재발급_테스트() throws Exception {
+
+        AuthToken authToken = new AuthToken(
+                jwtUtils.createAccessToken(USER_SOCIAL_ID),
+                jwtUtils.createRefreshToken(USER_SOCIAL_ID)
+        );
+
+        given(jwtService.reissueToken(anyString(), anyString())).willReturn(authToken);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/refresh-token")
+                .header(AUTHORIZATION, BEARER + jwtUtils.createRefreshToken(USER_SOCIAL_ID))
+                .header(REFRESH_HEADER, BEARER + jwtUtils.createRefreshToken(USER_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+}

--- a/src/test/java/com/palgona/palgona/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/palgona/palgona/controller/member/MemberControllerTest.java
@@ -1,0 +1,230 @@
+package com.palgona.palgona.controller.member;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palgona.palgona.common.dto.response.SliceResponse;
+import com.palgona.palgona.common.jwt.util.JwtUtils;
+import com.palgona.palgona.domain.member.Member;
+import com.palgona.palgona.domain.member.Role;
+import com.palgona.palgona.domain.member.Status;
+import com.palgona.palgona.dto.MemberDetailResponse;
+import com.palgona.palgona.dto.MemberResponse;
+import com.palgona.palgona.dto.MemberUpdateRequestWithoutImage;
+import com.palgona.palgona.service.MemberService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+    private static final String BEARER = "Bearer ";
+    private static final String ADMIN_SOCIAL_ID = "12345";
+    private static final String USER_SOCIAL_ID = "1234";
+    private static final String GUEST_SOCIAL_ID = "123";
+
+
+    @MockBean
+    MemberService memberService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    JwtUtils jwtUtils;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void 나의_프로필_정보를_확인한다() throws Exception {
+        MemberDetailResponse response = new MemberDetailResponse(
+                2L,
+                "palgona",
+                100,
+                "image.png"
+        );
+
+        given(memberService.findMyProfile(any())).willReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/my")
+                .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(USER_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.id").value(2L));
+    }
+
+    @Test
+    void 회원가입전에_프로필_조회하면_예외가_발생한다() throws Exception {
+        MemberDetailResponse response = new MemberDetailResponse(
+                2L,
+                "palgona",
+                100,
+                "image.png"
+        );
+
+        given(memberService.findMyProfile(any())).willReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/my")
+                        .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(GUEST_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isForbidden())
+                .andExpect(jsonPath("$.code").value("A_006"));
+    }
+
+    @Test
+    void 맴버_프로필_정보를_확인한다() throws Exception {
+        MemberResponse response = new MemberResponse(
+                2L,
+                "palgona",
+                "image.png"
+        );
+
+        given(memberService.findById(any())).willReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/2")
+                .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(USER_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.id").value(2));
+    }
+
+    @Test
+    void 회원가입전에_맴버_프로필_정보를_조회하면_예외가_발생한다() throws Exception {
+        MemberResponse response = new MemberResponse(
+                2L,
+                "palgona",
+                "image.png"
+        );
+
+        Member member = Member.of(100, Status.ACTIVE, "111", Role.GUEST);
+
+        given(memberService.findById(any())).willReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/2")
+                        .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(GUEST_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isForbidden())
+                .andExpect(jsonPath("$.code").value("A_006"))
+                .andDo(print());
+    }
+
+    @Test
+    void 모든_유저를_조회한다() throws Exception {
+        List<MemberResponse> memberResponses = List.of(
+                new MemberResponse(
+                        1L,
+                        "palgona1",
+                        "image1.png"
+                ),
+                new MemberResponse(
+                        2L,
+                        "palgona2",
+                        "image2.png"
+                )
+        );
+
+        SliceResponse<MemberResponse> response = new SliceResponse<>(memberResponses, true, "cursor");
+
+        given(memberService.findAllMember(any())).willReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members")
+                .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(ADMIN_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.values[0].id").value(1))
+                .andExpect(jsonPath("$.values[1].id").value(2));
+    }
+
+    @Test
+    void 관리자가_아니면_모든_유저를_조회할_수_없다() throws Exception {
+        List<MemberResponse> memberResponses = List.of(
+                new MemberResponse(
+                        1L,
+                        "palgona1",
+                        "image1.png"
+                ),
+                new MemberResponse(
+                        2L,
+                        "palgona2",
+                        "image2.png"
+                )
+        );
+
+        SliceResponse<MemberResponse> response = new SliceResponse<>(memberResponses, true, "cursor");
+
+        given(memberService.findAllMember(any())).willReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members")
+                        .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(USER_SOCIAL_ID)))
+                .andExpect(MockMvcResultMatchers.status().isForbidden())
+                .andExpect(jsonPath("$.code").value("A_006"));
+    }
+
+    @Test
+    void 유저_정보를_갱신한다() throws Exception {
+
+        MemberUpdateRequestWithoutImage memberUpdateRequestWithoutImage
+                = new MemberUpdateRequestWithoutImage("request");
+
+        MockMultipartFile request = new MockMultipartFile(
+                "request",
+                "request",
+                APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(memberUpdateRequestWithoutImage)
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(PUT, "/api/v1/members")
+                        .file(request)
+                        .file(image)
+                .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(USER_SOCIAL_ID))
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void 회원가입전에_유저_정보를_갱신하면_예외가_발생한다() throws Exception {
+
+        MemberUpdateRequestWithoutImage memberUpdateRequestWithoutImage
+                = new MemberUpdateRequestWithoutImage("request");
+
+        MockMultipartFile request = new MockMultipartFile(
+                "request",
+                "request",
+                APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(memberUpdateRequestWithoutImage)
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(PUT, "/api/v1/members")
+                        .file(request)
+                        .file(image)
+                        .header(AUTHORIZATION, BEARER + jwtUtils.createAccessToken(GUEST_SOCIAL_ID))
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+    }
+}

--- a/src/test/java/com/palgona/palgona/controller/member/MemberInitializer.java
+++ b/src/test/java/com/palgona/palgona/controller/member/MemberInitializer.java
@@ -1,0 +1,23 @@
+package com.palgona.palgona.controller.member;
+
+import com.palgona.palgona.domain.member.Member;
+import com.palgona.palgona.domain.member.Role;
+import com.palgona.palgona.domain.member.Status;
+import com.palgona.palgona.repository.member.MemberRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberInitializer {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @PostConstruct
+    public void init() {
+        memberRepository.save(Member.of(0, Status.ACTIVE, "123", Role.GUEST));
+        memberRepository.save(Member.of(0, Status.ACTIVE, "1234", Role.USER));
+        memberRepository.save(Member.of(0, Status.ACTIVE, "12345", Role.ADMIN));
+    }
+}

--- a/src/test/java/com/palgona/palgona/service/login/LoginServiceTest.java
+++ b/src/test/java/com/palgona/palgona/service/login/LoginServiceTest.java
@@ -1,0 +1,119 @@
+package com.palgona.palgona.service.login;
+
+import static com.palgona.palgona.common.error.code.MemberErrorCode.ALREADY_SIGNED_UP;
+import static com.palgona.palgona.common.error.code.MemberErrorCode.DUPLICATE_NAME;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
+import static org.mockito.BDDMockito.given;
+
+import com.palgona.palgona.common.dto.CustomMemberDetails;
+import com.palgona.palgona.common.error.exception.BusinessException;
+import com.palgona.palgona.domain.member.Member;
+import com.palgona.palgona.domain.member.Role;
+import com.palgona.palgona.domain.member.Status;
+import com.palgona.palgona.dto.MemberCreateRequest;
+import com.palgona.palgona.repository.member.MemberRepository;
+import com.palgona.palgona.service.LoginService;
+import com.palgona.palgona.service.image.S3Service;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class LoginServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    S3Service s3Service;
+
+    @InjectMocks
+    LoginService loginService;
+
+
+    @Test
+    void 회원가입_성공_테스트() {
+        Member member = Member.of(100, Status.ACTIVE, "111", Role.GUEST);
+        CustomMemberDetails customMemberDetails = new CustomMemberDetails(member);
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        MemberCreateRequest request = new MemberCreateRequest("name", image);
+
+        given(memberRepository.findBySocialId("111")).willReturn(Optional.of(member));
+        given(memberRepository.existsByNickName("name")).willReturn(false);
+        given(s3Service.upload(image)).willReturn("image.png");
+
+        loginService.signUp(customMemberDetails, request);
+
+        assertThat(member.getNickName()).isEqualTo("name");
+        assertThat(member.getProfileImage()).isEqualTo("image.png");
+    }
+
+    @Test
+    void 동일한_닉네임이_존재하면_에러가_발생한다() {
+        Member member = Member.of(100, Status.ACTIVE, "111", Role.GUEST);
+        CustomMemberDetails customMemberDetails = new CustomMemberDetails(member);
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        MemberCreateRequest request = new MemberCreateRequest("name", image);
+
+        given(memberRepository.findBySocialId("111")).willReturn(Optional.of(member));
+        given(memberRepository.existsByNickName("name")).willReturn(true);
+
+        assertThatThrownBy(() -> loginService.signUp(customMemberDetails, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(DUPLICATE_NAME.getMessage());
+    }
+
+
+    @Test
+    void 유저_ROLE이_USER이면_회원가입에_실패한다() {
+        Member member = Member.of(100, Status.ACTIVE, "111", Role.USER);
+        CustomMemberDetails customMemberDetails = new CustomMemberDetails(member);
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        MemberCreateRequest request = new MemberCreateRequest("name", image);
+
+        given(memberRepository.findBySocialId("111")).willReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> loginService.signUp(customMemberDetails, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ALREADY_SIGNED_UP.getMessage());
+    }
+
+    @Test
+    void 유저_ROLE이_ADMIN이면_회원가입에_실패한다() {
+        Member member = Member.of(100, Status.ACTIVE, "111", Role.ADMIN);
+        CustomMemberDetails customMemberDetails = new CustomMemberDetails(member);
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        MemberCreateRequest request = new MemberCreateRequest("name", image);
+
+        given(memberRepository.findBySocialId("111")).willReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> loginService.signUp(customMemberDetails, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ALREADY_SIGNED_UP.getMessage());
+    }
+}

--- a/src/test/java/com/palgona/palgona/service/member/MemberServiceTest.java
+++ b/src/test/java/com/palgona/palgona/service/member/MemberServiceTest.java
@@ -1,0 +1,61 @@
+package com.palgona.palgona.service.member;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
+
+import com.palgona.palgona.common.dto.CustomMemberDetails;
+import com.palgona.palgona.domain.member.Member;
+import com.palgona.palgona.domain.member.Role;
+import com.palgona.palgona.domain.member.Status;
+import com.palgona.palgona.dto.MemberUpdateRequest;
+import com.palgona.palgona.repository.member.MemberRepository;
+import com.palgona.palgona.service.MemberService;
+import com.palgona.palgona.service.image.S3Service;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    S3Service s3Service;
+
+    @InjectMocks
+    MemberService memberService;
+
+    @Test
+    void 유저_정보_갱신_테스트() {
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                IMAGE_PNG_VALUE,
+                "imageDummy".getBytes());
+
+        MemberUpdateRequest request = new MemberUpdateRequest("palgona", image);
+
+        Member loginMember = Member.of(100, Status.ACTIVE, "111", Role.USER);
+        CustomMemberDetails customMemberDetails = new CustomMemberDetails(loginMember);
+        Member target = Member.of(100, Status.ACTIVE, "111", Role.USER);
+
+        given(memberRepository.findBySocialId(any())).willReturn(Optional.of(target));
+        doNothing().when(s3Service).deleteFile(any());
+        given(s3Service.upload(any())).willReturn("123.png");
+
+        memberService.update(customMemberDetails, request);
+        assertThat(target.getNickName()).isEqualTo("palgona");
+        assertThat(target.getProfileImage()).isEqualTo("123.png");
+    }
+}


### PR DESCRIPTION
## 개요

- #36 
- #30 

## 작업사항

- RefreshToken 재발급 로직 구현
- 로그아웃 기능 구현

## 변경로직

- `JwtAuthenticationFileter`에서 인증 유저 체크할 때, 로그아웃된 유저의 accessToken으로 접근하면 인증 에러 발생하도록 변경
