### PR TITLE
Feat/#62 구매 및 마일리지 입출금 로직 구현

### DIFF
--- a/src/main/java/com/palgona/palgona/common/annotation/Retry.java
+++ b/src/main/java/com/palgona/palgona/common/annotation/Retry.java
@@ -1,0 +1,15 @@
+package com.palgona.palgona.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Retry {
+
+    int maxRetryCount() default 3;
+
+    long retryInterval() default 100L;
+}

--- a/src/main/java/com/palgona/palgona/common/aop/OptimisticLockAop.java
+++ b/src/main/java/com/palgona/palgona/common/aop/OptimisticLockAop.java
@@ -1,0 +1,38 @@
+package com.palgona.palgona.common.aop;
+
+import com.palgona.palgona.common.annotation.Retry;
+import jakarta.persistence.OptimisticLockException;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class OptimisticLockAop {
+
+    @Around("@annotation(com.palgona.palgona.common.annotation.Retry)")
+    public Object doRetry(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Retry retry = method.getAnnotation(Retry.class);
+        Exception exceptionHolder = null;
+        int maxRetryCount = retry.maxRetryCount();
+        long retryInterval = retry.retryInterval();
+        while (maxRetryCount-- > 0) {
+            try {
+                return joinPoint.proceed();
+
+            } catch (OptimisticLockException e) {
+                exceptionHolder = e;
+                Thread.sleep(retryInterval);
+            }
+        }
+
+        throw exceptionHolder;
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/MemberErrorCode.java
@@ -10,7 +10,8 @@ public enum MemberErrorCode implements ErrorCode {
     ADMIN_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "C_002", "관리자 권한으로만 접근할 수 있는 리소스입니다."),
     MEMBER_NOT_FOUND(HttpStatus.OK, "C_003", "해당 유저를 찾을 수 없습니다."),
     ALREADY_SIGNED_UP(HttpStatus.BAD_REQUEST, "C_004", "이미 회원가입된 유저입니다."),
-    DUPLICATE_NAME(HttpStatus.BAD_REQUEST, "C_005", "이미 존재하는 닉네임입니다.");
+    DUPLICATE_NAME(HttpStatus.BAD_REQUEST, "C_005", "이미 존재하는 닉네임입니다."),
+    INSUFFICIENT_MILEAGE(HttpStatus.BAD_REQUEST, "C_006", "마일리지가 부족합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/palgona/palgona/common/error/code/ProductErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/ProductErrorCode.java
@@ -12,7 +12,8 @@ public enum ProductErrorCode implements ErrorCode {
     DELETED_PRODUCT(HttpStatus.BAD_REQUEST, "P_003", "현재 삭제된 상품입니다."),
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "P_004", "유효하지 않은 상품 가격입니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "P_005", "유효하지 않은 상품 카테고리 입니다."),
-    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "P_006", "상품 판매 마감기한은 하루 이상이여야 합니다.");
+    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "P_006", "상품 판매 마감기한은 하루 이상이여야 합니다."),
+    NOT_FOUND(HttpStatus.OK, "P_007", "해당 상품이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/palgona/palgona/common/error/code/PurchaseErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/PurchaseErrorCode.java
@@ -1,0 +1,18 @@
+package com.palgona.palgona.common.error.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PurchaseErrorCode implements ErrorCode{
+
+    PURCHASE_NOT_FOUND(HttpStatus.OK, "PC_001", "구매 기록을 찾을 수 없습니다."),
+    INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "PC_002", "구매 기록에 대한 권한이 없습니다."),
+    PURCHASE_EXPIRED(HttpStatus.BAD_REQUEST, "PC_003", "이미 구매 확정 기간이 지났습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/palgona/palgona/controller/PurchaseController.java
+++ b/src/main/java/com/palgona/palgona/controller/PurchaseController.java
@@ -1,0 +1,60 @@
+package com.palgona.palgona.controller;
+
+import com.palgona.palgona.common.dto.CustomMemberDetails;
+import com.palgona.palgona.common.dto.response.SliceResponse;
+import com.palgona.palgona.dto.purchase.PurchaseCancelRequest;
+import com.palgona.palgona.dto.purchase.PurchaseResponse;
+import com.palgona.palgona.service.PurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/purchases")
+public class PurchaseController {
+
+    private final PurchaseService purchaseService;
+
+    @GetMapping
+    public ResponseEntity<SliceResponse<PurchaseResponse>> readPurchases(
+            @AuthenticationPrincipal CustomMemberDetails member,
+            @RequestParam(defaultValue = "20") int pageSize,
+            @RequestParam(required = false) String cursor
+    ) {
+
+        SliceResponse<PurchaseResponse> response = purchaseService.readPurchases(member.getMember(), pageSize, cursor);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{purchaseId}/confirm")
+    public ResponseEntity<Void> confirmPurchase(
+            @AuthenticationPrincipal CustomMemberDetails member,
+            @PathVariable Long purchaseId
+    ) {
+
+        purchaseService.confirmPurchase(member.getMember(), purchaseId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{purchaseId}/cancel")
+    public ResponseEntity<Void> cancelPurchase(
+            @AuthenticationPrincipal CustomMemberDetails member,
+            @PathVariable Long purchaseId,
+            @RequestBody PurchaseCancelRequest request
+    ) {
+
+        purchaseService.cancelPurchase(member.getMember(), purchaseId, request);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/palgona/palgona/domain/member/Member.java
+++ b/src/main/java/com/palgona/palgona/domain/member/Member.java
@@ -1,6 +1,9 @@
 package com.palgona.palgona.domain.member;
 
+import static com.palgona.palgona.common.error.code.MemberErrorCode.INSUFFICIENT_MILEAGE;
+
 import com.palgona.palgona.common.entity.BaseTimeEntity;
+import com.palgona.palgona.common.error.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,6 +34,9 @@ public class Member extends BaseTimeEntity {
     private String socialId;
 
     private String profileImage;
+
+    @Version
+    Long version;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -70,14 +77,17 @@ public class Member extends BaseTimeEntity {
         this.profileImage = imageUrl;
     }
 
-
     public void updateMileage(int after){ this.mileage = after; }
 
     public void signUp() {
         this.role = Role.USER;
     }
 
-    public void useMileage(int usage) {
+    public void useMileage(int usage) throws BusinessException {
+        if (mileage < usage) {
+            throw new BusinessException(INSUFFICIENT_MILEAGE);
+        }
+
         mileage -= usage;
     }
 

--- a/src/main/java/com/palgona/palgona/domain/member/Member.java
+++ b/src/main/java/com/palgona/palgona/domain/member/Member.java
@@ -77,4 +77,15 @@ public class Member extends BaseTimeEntity {
         this.role = Role.USER;
     }
 
+    public void useMileage(int usage) {
+        mileage -= usage;
+    }
+
+    public void refundMileage(int price) {
+        mileage += price;
+    }
+
+    public void receivePayment(int price) {
+        mileage += price;
+    }
 }

--- a/src/main/java/com/palgona/palgona/domain/member/Member.java
+++ b/src/main/java/com/palgona/palgona/domain/member/Member.java
@@ -35,9 +35,6 @@ public class Member extends BaseTimeEntity {
 
     private String profileImage;
 
-    @Version
-    Long version;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;

--- a/src/main/java/com/palgona/palgona/domain/mileage/MileageState.java
+++ b/src/main/java/com/palgona/palgona/domain/mileage/MileageState.java
@@ -2,7 +2,8 @@ package com.palgona.palgona.domain.mileage;
 
 public enum MileageState {
     CHARGE("CHARGE", "충전"),
-    USE("USE", "사용");
+    USE("USE", "사용"),
+    SALE("SALE", "판매");
 
     private final String key;
     private final String value;

--- a/src/main/java/com/palgona/palgona/domain/product/Product.java
+++ b/src/main/java/com/palgona/palgona/domain/product/Product.java
@@ -1,8 +1,6 @@
 package com.palgona.palgona.domain.product;
 
 import com.palgona.palgona.common.entity.BaseTimeEntity;
-import com.palgona.palgona.domain.bidding.Bidding;
-import com.palgona.palgona.domain.bookmark.Bookmark;
 import com.palgona.palgona.domain.member.Member;
 import jakarta.persistence.*;
 

--- a/src/main/java/com/palgona/palgona/domain/purchase/Purchase.java
+++ b/src/main/java/com/palgona/palgona/domain/purchase/Purchase.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -44,7 +45,7 @@ public class Purchase extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDateTime deadline;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bidding_id")
     private Bidding bidding;
 

--- a/src/main/java/com/palgona/palgona/domain/purchase/Purchase.java
+++ b/src/main/java/com/palgona/palgona/domain/purchase/Purchase.java
@@ -1,0 +1,88 @@
+package com.palgona.palgona.domain.purchase;
+
+import static com.palgona.palgona.common.error.code.PurchaseErrorCode.INSUFFICIENT_PERMISSION;
+import static com.palgona.palgona.common.error.code.PurchaseErrorCode.PURCHASE_EXPIRED;
+
+import com.palgona.palgona.common.entity.BaseTimeEntity;
+import com.palgona.palgona.common.error.exception.BusinessException;
+import com.palgona.palgona.domain.bidding.Bidding;
+import com.palgona.palgona.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Purchase extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int purchasePrice;
+
+    private String reason;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PurchaseState state;
+
+    @Column(nullable = false)
+    private LocalDateTime deadline;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bidding_id")
+    private Bidding bidding;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public Purchase(int purchasePrice, Bidding bidding, Member member) {
+        this.purchasePrice = purchasePrice;
+        this.bidding = bidding;
+        this.member = member;
+        this.reason = null;
+        this.state = PurchaseState.WAIT;
+        this.deadline = LocalDateTime.now().plusDays(1);
+    }
+
+    public void confirm() {
+        state = PurchaseState.CONFIRM;
+    }
+
+    public void updateReason(String reason) {
+        this.reason = reason;
+    }
+
+    public void cancel() {
+        state = PurchaseState.CANCEL;
+    }
+
+    public void validateDeadline(LocalDateTime now) {
+        if (deadline.isBefore(now)) {
+            throw new BusinessException(PURCHASE_EXPIRED);
+        }
+    }
+
+    public void validateOwner(Member member) {
+        if (!this.member.equals(member)) {
+            throw new BusinessException(INSUFFICIENT_PERMISSION);
+        }
+    }
+}

--- a/src/main/java/com/palgona/palgona/domain/purchase/PurchaseState.java
+++ b/src/main/java/com/palgona/palgona/domain/purchase/PurchaseState.java
@@ -1,0 +1,14 @@
+package com.palgona.palgona.domain.purchase;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum PurchaseState {
+    CONFIRM("CONFIRM", "확정"),
+    WAIT("WAIT", "대기"),
+    CANCEL("CANCEL", "취소");
+
+    private final String key;
+    private final String value;
+}

--- a/src/main/java/com/palgona/palgona/dto/purchase/PurchaseCancelRequest.java
+++ b/src/main/java/com/palgona/palgona/dto/purchase/PurchaseCancelRequest.java
@@ -1,0 +1,4 @@
+package com.palgona.palgona.dto.purchase;
+
+public record PurchaseCancelRequest(String reason) {
+}

--- a/src/main/java/com/palgona/palgona/dto/purchase/PurchaseResponse.java
+++ b/src/main/java/com/palgona/palgona/dto/purchase/PurchaseResponse.java
@@ -1,0 +1,30 @@
+package com.palgona.palgona.dto.purchase;
+
+import com.palgona.palgona.domain.product.Category;
+import com.palgona.palgona.domain.purchase.PurchaseState;
+import com.palgona.palgona.repository.purchase.queryDto.PurchaseQueryResponse;
+
+public record PurchaseResponse(
+        Long id,
+        Long productId,
+        int price,
+        Category category,
+        PurchaseState state,
+        String reason,
+        String productName,
+        String imageUrl
+) {
+
+    public static PurchaseResponse of(PurchaseQueryResponse response, String imageUrl) {
+        return new PurchaseResponse(
+                response.id(),
+                response.productId(),
+                response.price(),
+                response.category(),
+                response.state(),
+                response.reason(),
+                response.productName(),
+                imageUrl
+        );
+    }
+}

--- a/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
@@ -18,11 +18,11 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
     Page<Bidding> findAllByProduct(Pageable pageable, Product product);
 
-    @Lock(LockModeType.OPTIMISTIC)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT b FROM Bidding b "
             + "JOIN FETCH b.member m "
             + "WHERE b.state = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
-    List<Bidding> findExpiredBiddingsWithOptimisticLock(@Param("currentDateTime") LocalDateTime currentDateTime);
+    List<Bidding> findExpiredBiddingsWithPessimisticLock(@Param("currentDateTime") LocalDateTime currentDateTime);
     boolean existsByProduct(Product product);
 
     Optional<Integer> findHighestPriceByProduct(Product product);

--- a/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
@@ -1,6 +1,7 @@
 package com.palgona.palgona.repository;
 
 import com.palgona.palgona.domain.bidding.Bidding;
+import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.product.Product;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,9 +15,15 @@ import org.springframework.data.repository.query.Param;
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
     Page<Bidding> findAllByProduct(Pageable pageable, Product product);
-    @Query("SELECT b FROM Bidding b WHERE b.state = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
+    @Query("SELECT b FROM Bidding b "
+            + "JOIN FETCH b.member m "
+            + "WHERE b.state = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
     List<Bidding> findExpiredBiddings(@Param("currentDateTime") LocalDateTime currentDateTime);
     boolean existsByProduct(Product product);
 
     Optional<Integer> findHighestPriceByProduct(Product product);
+
+    boolean existsByMember(Member member);
+
+    Optional<Integer> findHighestPriceByMember(Member member);
 }

--- a/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/BiddingRepository.java
@@ -3,22 +3,26 @@ package com.palgona.palgona.repository;
 import com.palgona.palgona.domain.bidding.Bidding;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.product.Product;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
     Page<Bidding> findAllByProduct(Pageable pageable, Product product);
+
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("SELECT b FROM Bidding b "
             + "JOIN FETCH b.member m "
             + "WHERE b.state = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
-    List<Bidding> findExpiredBiddings(@Param("currentDateTime") LocalDateTime currentDateTime);
+    List<Bidding> findExpiredBiddingsWithOptimisticLock(@Param("currentDateTime") LocalDateTime currentDateTime);
     boolean existsByProduct(Product product);
 
     Optional<Integer> findHighestPriceByProduct(Product product);

--- a/src/main/java/com/palgona/palgona/repository/member/MemberRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/member/MemberRepository.java
@@ -16,10 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     Optional<Member> findBySocialId(String socialId);
 
-    @Lock(LockModeType.OPTIMISTIC)
-    @Query("select m from Member m where m.id = :id")
-    Optional<Member> findByIdWithOptimisticLock(Long id);
-
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select m from Member m where m.id = :id")
     Optional<Member> findByIdWithPessimisticLock(Long id);

--- a/src/main/java/com/palgona/palgona/repository/member/MemberRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/member/MemberRepository.java
@@ -1,15 +1,22 @@
 package com.palgona.palgona.repository.member;
 
 import com.palgona.palgona.domain.member.Member;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     boolean existsByNickName(String nickName);
 
     Optional<Member> findBySocialId(String socialId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select m from Member m where m.id = :id")
+    Optional<Member> findByIdWithOptimisticLock(Long id);
 }

--- a/src/main/java/com/palgona/palgona/repository/member/MemberRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/member/MemberRepository.java
@@ -19,4 +19,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     @Lock(LockModeType.OPTIMISTIC)
     @Query("select m from Member m where m.id = :id")
     Optional<Member> findByIdWithOptimisticLock(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select m from Member m where m.id = :id")
+    Optional<Member> findByIdWithPessimisticLock(Long id);
 }

--- a/src/main/java/com/palgona/palgona/repository/product/ProductRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/product/ProductRepository.java
@@ -2,7 +2,9 @@ package com.palgona.palgona.repository.product;
 
 import com.palgona.palgona.domain.product.Product;
 import com.palgona.palgona.repository.product.querydto.ProductDetailQueryResponse;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
@@ -20,4 +22,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     """)
     Optional<ProductDetailQueryResponse> findProductWithAll(long productId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p from Product p where p.id = :id")
+    Optional<Product> findByIdWithPessimisticLock(Long id);
 }

--- a/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepository.java
@@ -14,13 +14,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long>, PurchaseRepositoryCustom {
 
-    @Lock(LockModeType.OPTIMISTIC)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select pc from Purchase pc join fetch pc.bidding b join fetch b.member m")
-    Optional<Purchase> findByIdWithSellerAndOptimisticLock(Long id);
+    Optional<Purchase> findByIdWithSellerAndPessimisticLock(Long id);
 
-    @Lock(LockModeType.OPTIMISTIC)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select pc from Purchase pc join fetch pc.member m")
-    Optional<Purchase> findByIdWithBuyerAndOptimisticLock(Long id);
+    Optional<Purchase> findByIdWithBuyerAndPessimisticLock(Long id);
 
     @Query("select pc from Purchase pc "
             + "join fetch pc.member m "

--- a/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepository.java
@@ -1,0 +1,29 @@
+package com.palgona.palgona.repository.purchase;
+
+import com.palgona.palgona.domain.purchase.Purchase;
+import com.palgona.palgona.domain.purchase.PurchaseState;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PurchaseRepository extends JpaRepository<Purchase, Long>, PurchaseRepositoryCustom {
+
+    @Query("select pc from Purchase pc join fetch pc.bidding b join fetch b.member m")
+    Optional<Purchase> findByIdWithSeller(Long id);
+
+    @Query("select pc from Purchase pc join fetch pc.member m")
+    Optional<Purchase> findByIdWithBuyer(Long id);
+
+    @Query("select pc from Purchase pc "
+            + "join fetch pc.member m "
+            + "where pc.state = 'WAIT' and pc.deadline < :currentDateTime")
+    List<Purchase> findAllByDeadline(@Param("currentDateTime") LocalDateTime currentDateTime);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Purchase pc set pc.state = :state where pc.id in :purchaseCanceledIds")
+    int bulkUpdateState(List<Long> purchaseCanceledIds, PurchaseState state);
+}

--- a/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepository.java
@@ -2,21 +2,25 @@ package com.palgona.palgona.repository.purchase;
 
 import com.palgona.palgona.domain.purchase.Purchase;
 import com.palgona.palgona.domain.purchase.PurchaseState;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long>, PurchaseRepositoryCustom {
 
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("select pc from Purchase pc join fetch pc.bidding b join fetch b.member m")
-    Optional<Purchase> findByIdWithSeller(Long id);
+    Optional<Purchase> findByIdWithSellerAndOptimisticLock(Long id);
 
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("select pc from Purchase pc join fetch pc.member m")
-    Optional<Purchase> findByIdWithBuyer(Long id);
+    Optional<Purchase> findByIdWithBuyerAndOptimisticLock(Long id);
 
     @Query("select pc from Purchase pc "
             + "join fetch pc.member m "

--- a/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepositoryCustom.java
+++ b/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.palgona.palgona.repository.purchase;
+
+import com.palgona.palgona.common.dto.response.SliceResponse;
+import com.palgona.palgona.domain.member.Member;
+import com.palgona.palgona.dto.purchase.PurchaseResponse;
+
+public interface PurchaseRepositoryCustom {
+    SliceResponse<PurchaseResponse> findAllByMember(Member member, int pageSize, String cursor);
+}

--- a/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepositoryImpl.java
+++ b/src/main/java/com/palgona/palgona/repository/purchase/PurchaseRepositoryImpl.java
@@ -1,0 +1,118 @@
+package com.palgona.palgona.repository.purchase;
+
+import static com.palgona.palgona.domain.bidding.QBidding.bidding;
+import static com.palgona.palgona.domain.image.QImage.image;
+import static com.palgona.palgona.domain.product.QProduct.product;
+import static com.palgona.palgona.domain.product.QProductImage.productImage;
+import static com.palgona.palgona.domain.purchase.QPurchase.purchase;
+
+import com.palgona.palgona.common.dto.response.SliceResponse;
+import com.palgona.palgona.domain.member.Member;
+import com.palgona.palgona.dto.purchase.PurchaseResponse;
+import com.palgona.palgona.repository.product.querydto.ImageQueryResponse;
+import com.palgona.palgona.repository.purchase.queryDto.PurchaseQueryResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PurchaseRepositoryImpl implements PurchaseRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public SliceResponse<PurchaseResponse> findAllByMember(Member member, int pageSize, String cursor) {
+        List<PurchaseQueryResponse> purchaseQueryResponses = queryFactory.select(Projections.constructor(
+                        PurchaseQueryResponse.class,
+                        purchase.id,
+                        product.id,
+                        purchase.purchasePrice,
+                        product.category,
+                        purchase.state,
+                        purchase.reason,
+                        product.name
+                ))
+                .from(purchase)
+                .innerJoin(purchase.bidding, bidding)
+                .innerJoin(bidding.product, product)
+                .where(purchase.member.eq(member),
+                        ltPurchaseId(cursor))
+                .orderBy(purchase.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        List<ImageQueryResponse> imageQueryResponses = queryFactory.select(Projections.constructor(
+                        ImageQueryResponse.class,
+                        product.id,
+                        image.imageId,
+                        image.imageUrl))
+                .from(productImage)
+                .join(productImage.image, image)
+                .where(productImage.product.id.in(toProductIds(purchaseQueryResponses)))
+                .fetch();
+
+        Map<Long, List<ImageQueryResponse>> result = imageQueryResponses.stream()
+                .collect(Collectors.groupingBy(ImageQueryResponse::productId));
+
+        List<PurchaseResponse> purchaseResponses = purchaseQueryResponses.stream()
+                .map(response -> {
+                    List<ImageQueryResponse> images = result.get(response.id());
+                    Long minId = Long.MAX_VALUE;
+                    String imageUrl = null;
+                    for (ImageQueryResponse image : images) {
+                        if (minId > image.imageId()) {
+                            minId = image.imageId();
+                            imageUrl = image.imageUrl();
+                        }
+                    }
+
+                    return PurchaseResponse.of(response, imageUrl);
+                }).collect(Collectors.toList());
+
+        return convertToSlice(purchaseResponses, pageSize);
+    }
+
+    private SliceResponse<PurchaseResponse> convertToSlice(List<PurchaseResponse> purchases, int pageSize) {
+        if (purchases.isEmpty()) {
+            return SliceResponse.of(purchases, false, null);
+        }
+
+        boolean hasNext = existNextPage(purchases, pageSize);
+        if (hasNext) {
+            deleteLastPage(purchases, pageSize);
+        }
+
+        String nextCursor = String.valueOf(purchases.get(purchases.size() - 1));
+        return SliceResponse.of(purchases, hasNext, nextCursor);
+    }
+
+    private boolean existNextPage(List<PurchaseResponse> purchases, int pageSize) {
+        if (purchases.size() > pageSize) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private void deleteLastPage(List<PurchaseResponse> purchases, int pageSize) {
+        purchases.remove(pageSize);
+    }
+
+    private BooleanExpression ltPurchaseId(String cursor) {
+        if (cursor != null) {
+            return purchase.id.lt(Long.valueOf(cursor));
+        }
+
+        return null;
+    }
+
+    private List<Long> toProductIds(List<PurchaseQueryResponse> purchaseResponses) {
+        return purchaseResponses.stream()
+                .map(PurchaseQueryResponse::id)
+                .toList();
+    }
+}

--- a/src/main/java/com/palgona/palgona/repository/purchase/queryDto/PurchaseQueryResponse.java
+++ b/src/main/java/com/palgona/palgona/repository/purchase/queryDto/PurchaseQueryResponse.java
@@ -1,0 +1,15 @@
+package com.palgona.palgona.repository.purchase.queryDto;
+
+import com.palgona.palgona.domain.product.Category;
+import com.palgona.palgona.domain.purchase.PurchaseState;
+
+public record PurchaseQueryResponse(
+        Long id,
+        Long productId,
+        int price,
+        Category category,
+        PurchaseState state,
+        String reason,
+        String productName
+) {
+}

--- a/src/main/java/com/palgona/palgona/service/BatchScheduler.java
+++ b/src/main/java/com/palgona/palgona/service/BatchScheduler.java
@@ -11,12 +11,12 @@ public class BatchScheduler {
     private final BiddingService biddingService;
     private final PurchaseService purchaseService;
 
-    @Scheduled(cron = "0/30 * * * * ?") // 5분 주기로 실행
+    @Scheduled(cron = "0 * * * * *")
     public void checkBiddingExpiration() {
         biddingService.checkBiddingExpiration();
     }
 
-    @Scheduled(cron = "0 */5 * * * ?")
+    @Scheduled(cron = "0 * * * * *")
     public void checkPurchaseExpiration() {
         purchaseService.checkPurchaseExpiration();
     }

--- a/src/main/java/com/palgona/palgona/service/BatchScheduler.java
+++ b/src/main/java/com/palgona/palgona/service/BatchScheduler.java
@@ -9,9 +9,15 @@ import org.springframework.stereotype.Service;
 public class BatchScheduler {
 
     private final BiddingService biddingService;
+    private final PurchaseService purchaseService;
 
     @Scheduled(cron = "0/30 * * * * ?") // 5분 주기로 실행
     public void checkBiddingExpiration() {
         biddingService.checkBiddingExpiration();
+    }
+
+    @Scheduled(cron = "0 */5 * * * ?")
+    public void checkPurchaseExpiration() {
+        purchaseService.checkPurchaseExpiration();
     }
 }

--- a/src/main/java/com/palgona/palgona/service/BiddingService.java
+++ b/src/main/java/com/palgona/palgona/service/BiddingService.java
@@ -3,14 +3,18 @@ package com.palgona.palgona.service;
 import static com.palgona.palgona.common.error.code.BiddingErrorCode.BIDDING_EXPIRED_PRODUCT;
 import static com.palgona.palgona.common.error.code.BiddingErrorCode.BIDDING_INSUFFICIENT_BID;
 import static com.palgona.palgona.common.error.code.BiddingErrorCode.BIDDING_LOWER_PRICE;
+import static com.palgona.palgona.common.error.code.MemberErrorCode.MEMBER_NOT_FOUND;
 
 import com.palgona.palgona.common.error.exception.BusinessException;
 import com.palgona.palgona.domain.bidding.Bidding;
 import com.palgona.palgona.domain.bidding.BiddingState;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.product.Product;
+import com.palgona.palgona.domain.purchase.Purchase;
 import com.palgona.palgona.dto.BiddingAttemptRequest;
 import com.palgona.palgona.repository.BiddingRepository;
+import com.palgona.palgona.repository.purchase.PurchaseRepository;
+import com.palgona.palgona.repository.member.MemberRepository;
 import com.palgona.palgona.repository.product.ProductRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -27,11 +31,14 @@ import org.springframework.stereotype.Service;
 public class BiddingService {
     private final BiddingRepository biddingRepository;
     private final ProductRepository productRepository;
+    private final PurchaseRepository purchaseRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void attemptBidding(Member member, BiddingAttemptRequest request) {
         Product product = productRepository.findById(request.productId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 product가 없습니다."));
+
         int attemptPrice = request.price();
 
         if (product.isDeadlineReached()) {
@@ -68,31 +75,46 @@ public class BiddingService {
         List<Bidding> expiredBiddings = biddingRepository.findExpiredBiddings(LocalDateTime.now());
 
         Map<Long, Bidding> highestPriceBiddings = new HashMap<>();
+        Map<Member, Integer> memberHighestBids = new HashMap<>();
 
-        // expiredBiddings를 순회하며 각 product_id에 대한 가장 높은 price를 가진 Bidding을 저장
         for (Bidding bidding : expiredBiddings) {
             Long productId = bidding.getProduct().getId();
-
             highestPriceBiddings.compute(productId, (key, oldValue) -> {
                 if (oldValue == null || bidding.getPrice() > oldValue.getPrice() || (
                         bidding.getPrice() == oldValue.getPrice() && bidding.getUpdatedAt()
                                 .isBefore(oldValue.getUpdatedAt()))) {
                     return bidding;
-                } else {
-                    return oldValue;
                 }
+
+                return oldValue;
+            });
+
+            memberHighestBids.compute(bidding.getMember(), (member, currentBid) -> {
+                if (currentBid == null || currentBid < bidding.getPrice()) {
+                    return bidding.getPrice();
+                }
+
+                return currentBid;
             });
         }
 
         for (Bidding bidding : expiredBiddings) {
             Long productId = bidding.getProduct().getId();
             Bidding highestPriceBidding = highestPriceBiddings.get(productId);
-
-            // 가장 높은 가격을 가진 Bidding이면 SUCCESS로, 그렇지 않으면 FAILED로 상태 변경
             if (bidding.getId().equals(highestPriceBidding.getId())) {
                 bidding.updateState(BiddingState.SUCCESS);
+                Purchase purchase = Purchase.builder()
+                        .bidding(bidding)
+                        .member(bidding.getMember())
+                        .purchasePrice(bidding.getPrice())
+                        .build();
+
+                purchaseRepository.save(purchase);
             } else {
                 bidding.updateState(BiddingState.FAILED);
+                if (memberHighestBids.get(bidding.getMember()) == bidding.getPrice()) {
+                    bidding.getMember().refundMileage(bidding.getPrice());
+                }
             }
         }
     }

--- a/src/main/java/com/palgona/palgona/service/BiddingService.java
+++ b/src/main/java/com/palgona/palgona/service/BiddingService.java
@@ -111,7 +111,6 @@ public class BiddingService {
             });
         }
 
-        // 입찰자 마일리지 갱신할 때 동시성 처리
         for (Bidding bidding : expiredBiddings) {
             Long productId = bidding.getProduct().getId();
             Bidding highestPriceBidding = highestPriceBiddings.get(productId);

--- a/src/main/java/com/palgona/palgona/service/PurchaseService.java
+++ b/src/main/java/com/palgona/palgona/service/PurchaseService.java
@@ -37,7 +37,6 @@ public class PurchaseService {
     @Transactional
     @Retry
     public void confirmPurchase(Member member, Long id) {
-        //판매자 돈 변경할 때 동시성 처리
         Purchase purchase = findPurchaseWithSellerAndOptimisticLock(id);
         purchase.validateOwner(member);
         purchase.validateDeadline(LocalDateTime.now());
@@ -64,7 +63,6 @@ public class PurchaseService {
     @Transactional
     @Retry
     public void cancelPurchase(Member member, Long id, PurchaseCancelRequest request) {
-        //구매자 마일리지 복구할 때 동시성 처리
         Purchase purchase = findPurchaseWithBuyerAndOptimisticLock(id);
         purchase.validateOwner(member);
         purchase.validateDeadline(LocalDateTime.now());
@@ -77,7 +75,6 @@ public class PurchaseService {
 
     @Transactional
     public void checkPurchaseExpiration() {
-        //구매자 마일리지 변경할 때 동시성 처리
         List<Purchase> expiredPurchases = purchaseRepository.findAllByDeadline(LocalDateTime.now());
         List<Long> purchaseCanceledIds = new ArrayList<>();
         for (Purchase expiredPurchase : expiredPurchases) {

--- a/src/main/java/com/palgona/palgona/service/PurchaseService.java
+++ b/src/main/java/com/palgona/palgona/service/PurchaseService.java
@@ -1,0 +1,81 @@
+package com.palgona.palgona.service;
+
+import static com.palgona.palgona.common.error.code.PurchaseErrorCode.PURCHASE_NOT_FOUND;
+
+import com.palgona.palgona.common.dto.response.SliceResponse;
+import com.palgona.palgona.common.error.exception.BusinessException;
+import com.palgona.palgona.domain.member.Member;
+import com.palgona.palgona.domain.purchase.Purchase;
+import com.palgona.palgona.domain.purchase.PurchaseState;
+import com.palgona.palgona.dto.purchase.PurchaseCancelRequest;
+import com.palgona.palgona.dto.purchase.PurchaseResponse;
+import com.palgona.palgona.repository.purchase.PurchaseRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PurchaseService {
+
+    private static final double REFUND_RATE = 0.8;
+
+    private final PurchaseRepository purchaseRepository;
+
+    public SliceResponse<PurchaseResponse> readPurchases(Member member, int pageSize, String cursor) {
+        return purchaseRepository.findAllByMember(member, pageSize, cursor);
+    }
+
+    @Transactional
+    public void confirmPurchase(Member member, Long id) {
+        Purchase purchase = findPurchaseWithSeller(id);
+        purchase.validateOwner(member);
+        purchase.validateDeadline(LocalDateTime.now());
+        purchase.confirm();
+        Member seller = purchase.getBidding().getMember();
+        seller.receivePayment(purchase.getPurchasePrice());
+    }
+
+    @Transactional
+    public void cancelPurchase(Member member, Long id, PurchaseCancelRequest request) {
+        Purchase purchase = findPurchaseWithBuyer(id);
+        purchase.validateOwner(member);
+        purchase.validateDeadline(LocalDateTime.now());
+        purchase.cancel();
+        purchase.updateReason(request.reason());
+        Member buyer = purchase.getMember();
+        int refundAmount = calculateRefundAmount(purchase);
+        buyer.refundMileage(refundAmount);
+    }
+
+    @Transactional
+    public void checkPurchaseExpiration() {
+        List<Purchase> expiredPurchases = purchaseRepository.findAllByDeadline(LocalDateTime.now());
+        List<Long> purchaseCanceledIds = new ArrayList<>();
+        for (Purchase expiredPurchase : expiredPurchases) {
+            purchaseCanceledIds.add(expiredPurchase.getId());
+            Member buyer = expiredPurchase.getMember();
+            int refundAmount = calculateRefundAmount(expiredPurchase);
+            buyer.refundMileage(refundAmount);
+        }
+
+        purchaseRepository.bulkUpdateState(purchaseCanceledIds, PurchaseState.CANCEL);
+    }
+
+    private Purchase findPurchaseWithBuyer(Long id) {
+        return purchaseRepository.findByIdWithBuyer(id)
+                .orElseThrow(() -> new BusinessException(PURCHASE_NOT_FOUND));
+    }
+
+    private Purchase findPurchaseWithSeller(Long id) {
+        return purchaseRepository.findByIdWithSeller(id)
+                .orElseThrow(() -> new BusinessException(PURCHASE_NOT_FOUND));
+    }
+
+    private int calculateRefundAmount(Purchase purchase) {
+        return (int) (purchase.getPurchasePrice() * REFUND_RATE);
+    }
+}

--- a/src/main/java/com/palgona/palgona/service/PurchaseService.java
+++ b/src/main/java/com/palgona/palgona/service/PurchaseService.java
@@ -7,6 +7,7 @@ import com.palgona.palgona.common.dto.response.SliceResponse;
 import com.palgona.palgona.common.error.exception.BusinessException;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.mileage.MileageHistory;
+import com.palgona.palgona.domain.mileage.MileageState;
 import com.palgona.palgona.domain.purchase.Purchase;
 import com.palgona.palgona.domain.purchase.PurchaseState;
 import com.palgona.palgona.dto.purchase.PurchaseCancelRequest;
@@ -49,6 +50,7 @@ public class PurchaseService {
                 .beforeMileage(seller.getMileage() - purchaseAmount)
                 .afterMileage(seller.getMileage())
                 .amount(purchaseAmount)
+                .state(MileageState.SALE)
                 .member(seller)
                 .build());
 
@@ -56,6 +58,7 @@ public class PurchaseService {
                 .beforeMileage(member.getMileage() + purchaseAmount)
                 .afterMileage(member.getMileage())
                 .amount(purchaseAmount)
+                .state(MileageState.USE)
                 .member(member)
                 .build());
     }

--- a/src/main/java/com/palgona/palgona/service/PurchaseService.java
+++ b/src/main/java/com/palgona/palgona/service/PurchaseService.java
@@ -2,7 +2,6 @@ package com.palgona.palgona.service;
 
 import static com.palgona.palgona.common.error.code.PurchaseErrorCode.PURCHASE_NOT_FOUND;
 
-import com.palgona.palgona.common.annotation.Retry;
 import com.palgona.palgona.common.dto.response.SliceResponse;
 import com.palgona.palgona.common.error.exception.BusinessException;
 import com.palgona.palgona.domain.member.Member;
@@ -36,9 +35,8 @@ public class PurchaseService {
     }
 
     @Transactional
-    @Retry
     public void confirmPurchase(Member member, Long id) {
-        Purchase purchase = findPurchaseWithSellerAndOptimisticLock(id);
+        Purchase purchase = findPurchaseWithSellerAndPessimisticLock(id);
         purchase.validateOwner(member);
         purchase.validateDeadline(LocalDateTime.now());
         purchase.confirm();
@@ -64,9 +62,8 @@ public class PurchaseService {
     }
 
     @Transactional
-    @Retry
     public void cancelPurchase(Member member, Long id, PurchaseCancelRequest request) {
-        Purchase purchase = findPurchaseWithBuyerAndOptimisticLock(id);
+        Purchase purchase = findPurchaseWithBuyerAndPessimisticLock(id);
         purchase.validateOwner(member);
         purchase.validateDeadline(LocalDateTime.now());
         purchase.cancel();
@@ -90,13 +87,13 @@ public class PurchaseService {
         purchaseRepository.bulkUpdateState(purchaseCanceledIds, PurchaseState.CANCEL);
     }
 
-    private Purchase findPurchaseWithBuyerAndOptimisticLock(Long id) {
-        return purchaseRepository.findByIdWithBuyerAndOptimisticLock(id)
+    private Purchase findPurchaseWithBuyerAndPessimisticLock(Long id) {
+        return purchaseRepository.findByIdWithBuyerAndPessimisticLock(id)
                 .orElseThrow(() -> new BusinessException(PURCHASE_NOT_FOUND));
     }
 
-    private Purchase findPurchaseWithSellerAndOptimisticLock(Long id) {
-        return purchaseRepository.findByIdWithSellerAndOptimisticLock(id)
+    private Purchase findPurchaseWithSellerAndPessimisticLock(Long id) {
+        return purchaseRepository.findByIdWithSellerAndPessimisticLock(id)
                 .orElseThrow(() -> new BusinessException(PURCHASE_NOT_FOUND));
     }
 

--- a/src/test/java/com/palgona/palgona/service/bidding/BiddingServiceTest.java
+++ b/src/test/java/com/palgona/palgona/service/bidding/BiddingServiceTest.java
@@ -79,7 +79,7 @@ class BiddingServiceTest {
         // when
         when(productRepository.findByIdWithPessimisticLock(productId)).thenReturn(Optional.of(product));
         when(biddingRepository.findHighestPriceByProduct(product)).thenReturn(Optional.of(existingBidding.getPrice()));
-        when(memberRepository.findByIdWithOptimisticLock(any())).thenReturn(Optional.of(member));
+        when(memberRepository.findByIdWithPessimisticLock(any())).thenReturn(Optional.of(member));
         when(biddingRepository.findHighestPriceByMember(member)).thenReturn(Optional.of(0));
 
         // then

--- a/src/test/java/com/palgona/palgona/service/bidding/BiddingServiceTest.java
+++ b/src/test/java/com/palgona/palgona/service/bidding/BiddingServiceTest.java
@@ -11,6 +11,8 @@ import com.palgona.palgona.domain.product.Product;
 import com.palgona.palgona.domain.product.ProductState;
 import com.palgona.palgona.dto.BiddingAttemptRequest;
 import com.palgona.palgona.repository.BiddingRepository;
+import com.palgona.palgona.repository.purchase.PurchaseRepository;
+import com.palgona.palgona.repository.member.MemberRepository;
 import com.palgona.palgona.repository.product.ProductRepository;
 import com.palgona.palgona.service.BiddingService;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,12 +34,18 @@ class BiddingServiceTest {
     @Mock
     private ProductRepository productRepository;
 
+    @Mock
+    private PurchaseRepository purchaseRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
     private BiddingService biddingService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        biddingService = new BiddingService(biddingRepository, productRepository);
+        biddingService = new BiddingService(biddingRepository, productRepository, purchaseRepository, memberRepository);
     }
 
     @Test

--- a/src/test/java/com/palgona/palgona/service/bidding/BiddingServiceTest.java
+++ b/src/test/java/com/palgona/palgona/service/bidding/BiddingServiceTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 class BiddingServiceTest {
@@ -56,6 +57,7 @@ class BiddingServiceTest {
         String socialId = "1111";
         Role role = Role.USER;
         Member member = Member.of(mileage, status, socialId, role);
+        member.updateMileage(1600);
 
         long productId = 1L;
         String productName = "상품";
@@ -75,8 +77,10 @@ class BiddingServiceTest {
         BiddingAttemptRequest request = new BiddingAttemptRequest(productId, attemptPrice);
 
         // when
-        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(productRepository.findByIdWithPessimisticLock(productId)).thenReturn(Optional.of(product));
         when(biddingRepository.findHighestPriceByProduct(product)).thenReturn(Optional.of(existingBidding.getPrice()));
+        when(memberRepository.findByIdWithOptimisticLock(any())).thenReturn(Optional.of(member));
+        when(biddingRepository.findHighestPriceByMember(member)).thenReturn(Optional.of(0));
 
         // then
         assertDoesNotThrow(() -> biddingService.attemptBidding(member, request));
@@ -105,7 +109,7 @@ class BiddingServiceTest {
         BiddingAttemptRequest request = new BiddingAttemptRequest(productId, attemptPrice);
 
         // when
-        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(productRepository.findByIdWithPessimisticLock(productId)).thenReturn(Optional.of(product));
 
         // then
         BusinessException exception = assertThrows(BusinessException.class,
@@ -139,7 +143,7 @@ class BiddingServiceTest {
         BiddingAttemptRequest request = new BiddingAttemptRequest(productId, attemptPrice);
 
         // when
-        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(productRepository.findByIdWithPessimisticLock(productId)).thenReturn(Optional.of(product));
         when(biddingRepository.findHighestPriceByProduct(product)).thenReturn(Optional.of(existingBidding.getPrice()));
 
         // then
@@ -174,7 +178,7 @@ class BiddingServiceTest {
         BiddingAttemptRequest request = new BiddingAttemptRequest(productId, attemptPrice);
 
         // when
-        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(productRepository.findByIdWithPessimisticLock(productId)).thenReturn(Optional.of(product));
         when(biddingRepository.findHighestPriceByProduct(product)).thenReturn(Optional.of(existingBidding.getPrice()));
 
         // then


### PR DESCRIPTION
## 개요

- 구매 기능 구현
- close #62 


## 작업사항

- 구매 확정, 취소 기능 및 마일리지 입출금 기능 구현
- 마일리지 갱신 시 충돌 발생은 재시도 Aop를 통해 처리
- 입찰 시 PessimisticLock을 걸어서 입찰 시도가 접근 순서에 따라 처리되도록 수정함.

## 변경로직

- 입찰할 때 입찰자의 마일리지가 차감되도록 변경
- 마감된 입찰 처리할 때 최고 입찰가를 제외한 입찰자의 마일리지 복구되도록 변경

## 전달사항
테스트 작성해서 추가로 올릴게요