### PR TITLE
채팅 브로커 Redis로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,70 +1,74 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.palgona'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    configureEach {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	//jwt
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	implementation 'org.springframework.boot:spring-boot-starter-batch'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation("org.springframework.security:spring-security-messaging")
 
-	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 
-	//s3
-	implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.1000')
-	implementation 'com.amazonaws:aws-java-sdk-s3'
+    //s3
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.1000')
+    implementation 'com.amazonaws:aws-java-sdk-s3'
 
-	runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.h2database:h2'
 
-	//querydsl
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.batch:spring-batch-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 tasks.named("jar") {
-	enabled = false
+    enabled = false
 }
 

--- a/src/main/java/com/palgona/palgona/common/WebSocket/AuthChannelInterceptor.java
+++ b/src/main/java/com/palgona/palgona/common/WebSocket/AuthChannelInterceptor.java
@@ -1,0 +1,33 @@
+package com.palgona.palgona.common.WebSocket;
+
+import com.palgona.palgona.common.jwt.util.JwtUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class AuthChannelInterceptor implements ChannelInterceptor {
+    private final JwtUtils jwtUtils;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        if (StompCommand.CONNECT == accessor.getCommand()) {
+            String jwtToken = accessor.getFirstNativeHeader("Authorization");
+            try {
+                jwtUtils.isExpired(jwtToken);
+            } catch (Exception e) {
+                log.info("socket jwt exception {}", e.getMessage());
+                throw e;
+            }
+        }
+        return message;
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/WebSocket/RedisChatSubscriber.java
+++ b/src/main/java/com/palgona/palgona/common/WebSocket/RedisChatSubscriber.java
@@ -1,0 +1,33 @@
+package com.palgona.palgona.common.WebSocket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palgona.palgona.dto.chat.ChatMessageResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class RedisChatSubscriber implements MessageListener {
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, Object> redisChatTemplate;
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String publishMessage = redisChatTemplate.getStringSerializer().deserialize(message.getBody());
+        ChatMessageResponse response;
+        try {
+            response = objectMapper.readValue(publishMessage, ChatMessageResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        messagingTemplate.convertAndSend("/sub/chatroom/" + response.roomId(), response);
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/palgona/palgona/common/entity/BaseTimeEntity.java
@@ -1,5 +1,10 @@
 package com.palgona.palgona.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -13,11 +18,16 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 public class BaseTimeEntity {
-
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
     @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/palgona/palgona/config/RedisConfig.java
+++ b/src/main/java/com/palgona/palgona/config/RedisConfig.java
@@ -1,11 +1,16 @@
 package com.palgona.palgona.config;
 
+import com.palgona.palgona.common.WebSocket.RedisChatSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -29,5 +34,35 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter listenerAdapter,
+            ChannelTopic channelTopic) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, channelTopic);
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisChatSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisChatTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        return redisTemplate;
+    }
+
+    @Bean
+    public ChannelTopic channelTopic() {
+        return new ChannelTopic("chatroom");
     }
 }

--- a/src/main/java/com/palgona/palgona/config/SecurityConfig.java
+++ b/src/main/java/com/palgona/palgona/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                     exceptionHandlingConfigurer.accessDeniedHandler(jwtAccessDeniedHandler);
                 })
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/ws").permitAll()
                         .requestMatchers("/api/v1/auth/login", "/api/v1/tests").permitAll()
                         .requestMatchers("/api/v1/auth/signup").hasRole(GUEST)
                         .requestMatchers("api/v1/auth/logout", "api/v1/auth/refresh-token").hasRole(USER)

--- a/src/main/java/com/palgona/palgona/config/WebSocketConfig.java
+++ b/src/main/java/com/palgona/palgona/config/WebSocketConfig.java
@@ -1,14 +1,22 @@
 package com.palgona.palgona.config;
 
+import com.palgona.palgona.common.WebSocket.AuthChannelInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final AuthChannelInterceptor authChannelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -23,4 +31,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOrigins("*");
     }
 
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(authChannelInterceptor);
+    }
 }

--- a/src/main/java/com/palgona/palgona/controller/ChatController.java
+++ b/src/main/java/com/palgona/palgona/controller/ChatController.java
@@ -7,6 +7,8 @@ import com.palgona.palgona.dto.chat.*;
 import com.palgona.palgona.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -21,10 +23,12 @@ import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/api/v1/chats")
 public class ChatController {
     private final ChatService chatService;
     private final SimpMessageSendingOperations messagingTemplate;
+    private final RedisTemplate<String, Object> redisChatTemplate;
 
     // TODO
     // 1번 멤버로 강제로 바꾸는 코드 없애야함.
@@ -42,7 +46,8 @@ public class ChatController {
     public void sendMessage(@Payload ChatMessageRequest message) {
         ChatMessage savedMessage = chatService.sendMessage(message);
         ChatMessageResponse messageResponse = ChatMessageResponse.from(savedMessage);
-        messagingTemplate.convertAndSend("/sub/topic/chat/" + savedMessage.getRoom().getId(), messageResponse);
+        redisChatTemplate.convertAndSend("chatroom", messageResponse);
+//        messagingTemplate.convertAndSend("/sub/chatroom/" + savedMessage.getRoom().getId(), messageResponse);
     }
 
     @PostMapping

--- a/src/main/java/com/palgona/palgona/dto/chat/ChatMessageResponse.java
+++ b/src/main/java/com/palgona/palgona/dto/chat/ChatMessageResponse.java
@@ -1,9 +1,29 @@
 package com.palgona.palgona.dto.chat;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.palgona.palgona.domain.chat.ChatMessage;
+import java.time.LocalDateTime;
 
-public record ChatMessageResponse(Long id, Long senderId, Long receiverId, String message, Long roomId) {
+public record ChatMessageResponse(Long id,
+                                  Long senderId,
+                                  Long receiverId,
+                                  String message,
+                                  Long roomId,
+                                  @JsonSerialize(using = LocalDateTimeSerializer.class) @JsonDeserialize(using = LocalDateTimeDeserializer.class) @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                          pattern = "yyyy-MM-dd HH:mm") LocalDateTime createdAt,
+                                  @JsonSerialize(using = LocalDateTimeSerializer.class) @JsonDeserialize(using = LocalDateTimeDeserializer.class) @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                          pattern = "yyyy-MM-dd HH:mm") LocalDateTime updatedAt) {
     public static ChatMessageResponse from(ChatMessage message) {
-        return new ChatMessageResponse(message.getId(), message.getSender().getId(), message.getReceiver().getId(), message.getMessage(), message.getRoom().getId());
+        return new ChatMessageResponse(message.getId(),
+                message.getSender().getId(),
+                message.getReceiver().getId(),
+                message.getMessage(),
+                message.getRoom().getId(),
+                message.getCreatedAt(),
+                message.getUpdatedAt());
     }
 }


### PR DESCRIPTION
## 개요

- Redis pub/sub를 소켓 통신 브로커로 변경 (#77)

## 작업사항

- Stomp의 simpleBroker도 사용하면서 redis를 사용하게 변경
- socket 통신(socket connect하는 handshake에서 jwt 토큰 인증하게 변경)

## 변경로직

- BaseTimeEntity에 json serialization 관련 어노테이션 추가

## 참고
broker 자체를 redis로 만드는 방법도 있으나 그럴 경우 redis의 sub/pub 채널이 많아져 좋지 않아보였어요.
redis로 변경하면서 서버가 여러대일 경우의 문제는 해결되었지만 여러대 중 한대가 다운될 경우 데이터가 유지안되는 특성은 다른 mq로 넘어가야 없어지겠네요..
