### PR TITLE
Fix: 마일리지 API 오류 수정 

### DIFF
--- a/src/main/java/com/palgona/palgona/repository/MileageHistoryRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/MileageHistoryRepository.java
@@ -2,12 +2,14 @@ package com.palgona.palgona.repository;
 
 import com.palgona.palgona.domain.mileage.MileageHistory;
 import com.palgona.palgona.domain.member.Member;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MileageHistoryRepository extends JpaRepository<MileageHistory, Long> {
     @Query("SELECT mh FROM MileageHistory mh WHERE mh.member = :member ORDER BY mh.createdAt DESC")
-    Optional<MileageHistory> findTopByMember(Member member);
+    List<MileageHistory> findTopByMember(Member member, Pageable pageable);
 }


### PR DESCRIPTION

## 개요

- 마일리지 API 오류 수정 

## 작업사항

#95

## 변경로직

- JWTFilter에서 가져온 member 객체가 준영속 상태로 관리되어, 엔티티의 상태 변화가 데이터베이스에 반영X
  - memberRepository.save(member) 호출을 통해 member 객체를 다시 영속 상태로 변경
- 마일리지 기록이 여러개일 경우 Optional<MileageHistory>로 반환 시 오류 발생
  - PageRequest.of(0, 1)을 사용하여 가장 최신의 기록 한 개만 가져옴
