### PR TITLE
feat: 상품 찜 리스트 전제 조회 API 구현

### DIFF
--- a/src/main/java/com/palgona/palgona/controller/BookmarkController.java
+++ b/src/main/java/com/palgona/palgona/controller/BookmarkController.java
@@ -1,12 +1,17 @@
 package com.palgona.palgona.controller;
 
 import com.palgona.palgona.common.dto.CustomMemberDetails;
+import com.palgona.palgona.common.dto.response.SliceResponse;
+import com.palgona.palgona.dto.BookmarkProductsResponse;
+import com.palgona.palgona.dto.response.ProductPageResponse;
 import com.palgona.palgona.service.BookmarkService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,5 +35,17 @@ public class BookmarkController {
         bookmarkService.deleteBookmark(productId, member);
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    @Operation(summary = "북마크 리스트 조회 api", description = "해당 멤버의 상품찜 리스트를 보여준다.")
+    public ResponseEntity<SliceResponse<BookmarkProductsResponse>> readALlBookmark(
+            @AuthenticationPrincipal CustomMemberDetails memberDetails,
+            @RequestParam(required = false, defaultValue = "0") int cursor,
+            @RequestParam(defaultValue = "20") int size){
+
+        SliceResponse<BookmarkProductsResponse> responses = bookmarkService.readALlBookmark(memberDetails, cursor, size);
+
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/palgona/palgona/dto/BookmarkProductsResponse.java
+++ b/src/main/java/com/palgona/palgona/dto/BookmarkProductsResponse.java
@@ -1,0 +1,14 @@
+package com.palgona.palgona.dto;
+
+import java.time.LocalDateTime;
+
+public record BookmarkProductsResponse(
+        Long id,
+        String name,
+        LocalDateTime deadline,
+        LocalDateTime created_at,
+        Integer currentBid,
+        Long bookmarkCount,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/palgona/palgona/repository/BookmarkRepository.java
+++ b/src/main/java/com/palgona/palgona/repository/BookmarkRepository.java
@@ -3,6 +3,8 @@ package com.palgona.palgona.repository;
 import com.palgona.palgona.domain.bookmark.Bookmark;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.product.Product;
+import com.palgona.palgona.dto.BookmarkProductsResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +22,21 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
         where b.product = :product
     """)
     void deleteByProduct(Product product);
+
+    @Query("""
+        select new com.palgona.palgona.dto.BookmarkProductsResponse(
+            p.id,
+            p.name,
+            p.deadline,
+            p.createdAt,
+            (select b.price from Bidding b where b.product = p order by b.createdAt DESC limit 1),
+            (select count(bm) from Bookmark bm where bm.product = p),
+            (select i.imageUrl from ProductImage pi join Image i on pi.image = i where pi.product = p order by pi.id ASC limit 1)
+        )
+        from Bookmark b
+        join b.product p
+        where b.member = :member and p.productState != 'DELETED'
+        group by p.id, p.name, p.deadline, p.createdAt
+    """)
+    List<BookmarkProductsResponse> findBookmarkedProductsByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/palgona/palgona/service/BookmarkService.java
+++ b/src/main/java/com/palgona/palgona/service/BookmarkService.java
@@ -1,15 +1,22 @@
 package com.palgona.palgona.service;
 
 import com.palgona.palgona.common.dto.CustomMemberDetails;
+import com.palgona.palgona.common.dto.response.SliceResponse;
 import com.palgona.palgona.common.error.exception.BusinessException;
 import com.palgona.palgona.domain.bookmark.Bookmark;
 import com.palgona.palgona.domain.member.Member;
 import com.palgona.palgona.domain.product.Product;
+import com.palgona.palgona.dto.BookmarkProductsResponse;
+import com.palgona.palgona.dto.NotificationResponse;
+import com.palgona.palgona.dto.response.ProductPageResponse;
 import com.palgona.palgona.repository.BookmarkRepository;
 import com.palgona.palgona.repository.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.palgona.palgona.common.error.code.BookmarkErrorCode.BOOKMARK_EXISTS;
 import static com.palgona.palgona.common.error.code.BookmarkErrorCode.BOOKMARK_NOT_EXISTS;
@@ -17,6 +24,7 @@ import static com.palgona.palgona.common.error.code.ProductErrorCode.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final ProductRepository productRepository;
@@ -56,5 +64,30 @@ public class BookmarkService {
 
         //3. 찜 삭제
         bookmarkRepository.delete(bookmark);
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<BookmarkProductsResponse> readALlBookmark(CustomMemberDetails memberDetails, int cursor, int size){
+        Member member = memberDetails.getMember();
+        PageRequest limit = PageRequest.of(cursor, size);
+
+        //멤버의 상품찜 목록에 있는 상품 전체 가져오기
+        // 상품 정보 + 입찰 최신 정보 + 해당 상품의 북마크 개수 + 상품의 첫번째 이미지
+        // 이때 삭제된 상품은 제외한다.
+        List<BookmarkProductsResponse> queryResults = bookmarkRepository.findBookmarkedProductsByMember(member, limit);
+
+        return convertToSlice(queryResults, cursor);
+    }
+
+
+    private SliceResponse<BookmarkProductsResponse> convertToSlice(List<BookmarkProductsResponse> items, int nowCursor){
+        boolean hasNext = true;
+        if(items.isEmpty()) {
+            hasNext = false;
+        }
+
+        String nextCursor = String.valueOf(nowCursor + 1);
+
+        return SliceResponse.of(items, hasNext, nextCursor);
     }
 }


### PR DESCRIPTION
## 개요

- 사용자가 찜한 상품 리스트를 한 번의 JPQL 쿼리로 조회하고, 페이징 처리를 추가하여 효율적으로 데이터를 가져오기.

## 작업사항

#103

## 변경로직

- JPQL로 DTO 조회를 위한 서브쿼리 작성:
  - 최신 입찰가: Bidding 테이블에서 가장 최근 입찰가를 가져오는 서브쿼리 작성.
  - 찜 개수: Bookmark 테이블에서 특정 상품에 대한 찜 개수를 세는 서브쿼리 작성.
  - 첫 번째 이미지 URL: ProductImage와 Image 테이블을 조인하여 첫 번째 이미지를 가져오는 서브쿼리 작성.
- 페이징 처리 추가: Pageable 파라미터를 사용하여 페이징 처리