### PR TITLE
fix: 채팅방에 있는 멤버 확인을 id만 하게 변경

### DIFF
--- a/src/main/java/com/palgona/palgona/domain/chat/ChatRoom.java
+++ b/src/main/java/com/palgona/palgona/domain/chat/ChatRoom.java
@@ -50,7 +50,7 @@ public class ChatRoom extends BaseTimeEntity {
     }
 
     public boolean hasMember(Member member) {
-        return member.equals(sender) || member.equals(receiver);
+        return member.getId().equals(sender.getId()) || member.getId().equals(receiver.getId());
     }
 }
 

--- a/src/main/java/com/palgona/palgona/domain/chat/ChatRoom.java
+++ b/src/main/java/com/palgona/palgona/domain/chat/ChatRoom.java
@@ -50,7 +50,7 @@ public class ChatRoom extends BaseTimeEntity {
     }
 
     public boolean hasMember(Member member) {
-        return member.getId().equals(sender.getId()) || member.getId().equals(receiver.getId());
+        return member.equals(sender) || member.equals(receiver);
     }
 }
 

--- a/src/main/java/com/palgona/palgona/service/ChatService.java
+++ b/src/main/java/com/palgona/palgona/service/ChatService.java
@@ -79,9 +79,10 @@ public class ChatService {
     public void readMessage(Member member, ReadMessageRequest request) {
         // 가장 최근에 읽은 데이터를 표시해야함.
         // 현재 연결되어서 바로 읽었는지 확인이 필요함.
+        Member receiver = findMember(member.getId());
         ChatMessage message = chatMessageRepository.findById(request.messageId())
                 .orElseThrow(() -> new BusinessException(ChatErrorCode.MESSAGE_NOT_FOUND));
-        ChatReadStatus chatReadStatus = chatReadStatusRepository.findByMemberAndRoom(member, message.getRoom());
+        ChatReadStatus chatReadStatus = chatReadStatusRepository.findByMemberAndRoom(receiver, message.getRoom());
         chatReadStatus.updateCursor(message.getId());
         chatReadStatusRepository.save(chatReadStatus);
     }


### PR DESCRIPTION
## 개요

- 채팅방에 없는 유저라고 나오는 경우가 생기는 문제

## 작업사항

- ~~Chatroom에서 멤버 객체 비교가 아닌 id만 비교하게 변경~~ revert
- [token에서 가져온 member가 아닌 memberId로 찾아오게 변경](https://github.com/Palgona/Backend/pull/113/commits/8ac8e93cf383583805d8bd4c2c6a0d3601434ae2)

