### PR TITLE
feat: 서브 모듈 도입

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "palgona-yml-manager"]
+	path = palgona-yml-manager
+	url = https://github.com/Palgona/palgona-yml-manager.git

--- a/build.gradle
+++ b/build.gradle
@@ -72,3 +72,29 @@ tasks.named("jar") {
     enabled = false
 }
 
+tasks.register('copyYml', Copy) {
+    from "./palgona-yml-manager/yml/main"
+    include "*.yml"
+    into "./src/main/resources"
+}
+
+tasks.register('copyJson', Copy) {
+    from "./palgona-yml-manager/yml/main"
+    include "*.json"
+    into "./src/main/resources"
+}
+
+tasks.register('copyTestJson', Copy) {
+    from "./palgona-yml-manager/yml/test"
+    include "*.json"
+    into "./src/test/resources"
+}
+
+tasks.register('copyTestYml', Copy) {
+    from "./palgona-yml-manager/yml/test"
+    include "*.yml"
+    into "./src/test/resources"
+}
+
+processResources.dependsOn('copyJson', 'copyYml')
+processTestResources.dependsOn('copyTestJson', 'copyTestYml')


### PR DESCRIPTION
## 개요

resolve #119 

- 서브 모듈 기능을 프로젝트에 도입합니다.
- 서브 모듈에 변경사항이 있다면 먼저 푸쉬하고 메인 프로젝트에서 서브모듈을 업데이트 해주면 됩니다.
- 프로젝트를 빌드하면 자동으로 yml 파일 및 FCM key가 resource로 import 됩니다.
  - Gradle -> Tasks -> build -> build

## 작업사항

- 서브모듈 private repository를 생성하고 yml파일을 옮겨놨습니다.
- 서브모듈을 자동으로 import하는 스크립트를 작성했습니다.